### PR TITLE
Add Alicat MFC and Hamilton probe modules for bioreactor control

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,33 @@ These modules can be imported from the Configuration submenus titled Inputs, Out
 Custom Inputs
 =============
 
+Alicat Mass Flow Controller (Modbus RTU)
+----------------------------------------
+
+Details and code: `Mycodo-custom/custom_inputs/alicat mfc/ <https://github.com/kizniche/Mycodo-custom/blob/master/custom_inputs/alicat%20mfc>`__
+
+This Input module reads telemetry data from Alicat Mass Flow Controllers via Modbus RTU serial communication. Provides real-time monitoring of volumetric flow, mass flow, pressure, temperature, and current setpoint values. Uses RS-485 serial connection over USB adapter.
+
+--------------
+
+Hamilton pH Probe (Modbus RTU)
+------------------------------
+
+Details and code: `Mycodo-custom/custom_inputs/hamilton arc ph probe/ <https://github.com/kizniche/Mycodo-custom/blob/master/custom_inputs/hamilton%20arc%20ph%20probe>`__
+
+This Input module reads pH and temperature measurements from Hamilton ARC pH probes via Modbus RTU serial communication. Provides high-accuracy pH monitoring for industrial and laboratory applications including bioreactors, fermenters, and aquaculture systems.
+
+--------------
+
+Hamilton DO Probe (Modbus RTU)
+------------------------------
+
+Details and code: `Mycodo-custom/custom_inputs/hamilton arc do probe/ <https://github.com/kizniche/Mycodo-custom/blob/master/custom_inputs/hamilton%20arc%20do%20probe>`__
+
+This Input module reads dissolved oxygen (DO) and temperature measurements from Hamilton ARC DO probes via Modbus RTU serial communication. Provides high-accuracy DO monitoring for bioreactors, fermenters, and aquaculture systems with digital Modbus communication.
+
+--------------
+
 LoRaWAN-enabled Geiger Counter
 ------------------------------
 
@@ -71,6 +98,15 @@ LoRaWAN transceiver that then receives those measurements and transmits them to 
 Custom Outputs
 ==============
 
+Alicat Mass Flow Controller Setpoint (Modbus RTU)
+-------------------------------------------------
+
+Details and code: `Mycodo-custom/custom_outputs/alicat massflow setpoint/ <https://github.com/kizniche/Mycodo-custom/blob/master/custom_outputs/alicat%20massflow%20setpoint>`__
+
+This Output module controls the setpoint of Alicat Mass Flow Controllers via Modbus RTU serial communication. Provides a value-type output that allows Mycodo automations, PID controllers, or manual commands to dynamically adjust flow rate. Includes verification by reading back the actual setpoint.
+
+--------------
+
 On/Off Remote GPIO (gpiozero)
 -----------------------------
 
@@ -95,6 +131,24 @@ Remotely control GPIO pin duty cycles over a network with the use of [gpiozero](
 
 Custom Functions
 ================
+
+pH Control (CO2 Mass Flow Controller)
+-------------------------------------
+
+Details and code: `Mycodo-custom/custom_functions/ph controller/ <https://github.com/kizniche/Mycodo-custom/blob/master/custom_functions/ph%20controller>`__
+
+This Function implements PID-based control for maintaining a pH setpoint by regulating CO2 flow through an Alicat Mass Flow Controller. Automatically adjusts CO2 dosing to keep pH stable in bioreactors, fermenters, or aquaculture systems. Includes configurable PID gains, safety flow limits, and measurement timeout protection.
+
+--------------
+
+DO Control (Air Mass Flow Controller)
+-------------------------------------
+
+Details and code: `Mycodo-custom/custom_functions/dissolved oxygen controller/ <https://github.com/kizniche/Mycodo-custom/blob/master/custom_functions/dissolved%20oxygen%20controller>`__
+
+This Function implements PID-based control for maintaining a dissolved oxygen (DO) setpoint by regulating air flow through an Alicat Mass Flow Controller. Automatically adjusts air/O2 dosing to keep DO stable in bioreactors, fermenters, or aquaculture systems. Includes configurable PID gains, safety flow limits, and measurement timeout protection.
+
+--------------
 
 CoolBot Clone
 -------------

--- a/custom_functions/dissolved oxygen controller/CHANGELOG.md
+++ b/custom_functions/dissolved oxygen controller/CHANGELOG.md
@@ -1,0 +1,67 @@
+## Changelog - DO Control (Air MFC)
+
+### Version 1.0 (2025-01-14)
+
+**Initial Release**
+
+**Features:**
+- PID-based dissolved oxygen control using air mass flow controller
+- Direct control logic (air raises DO)
+- Configurable Kp, Ki, Kd gains for tuning
+- Min/max flow rate limits for safety
+- Measurement timeout protection (stops flow if sensor fails)
+- Real-time logging of PID components and control variables
+- Compatible with any Mycodo Input providing DO measurements
+- Compatible with Alicat MFC outputs
+
+**Default Settings:**
+- DO Setpoint: 8.0 mg/L
+- Kp: 10.0 (proportional gain)
+- Ki: 0.5 (integral gain)
+- Kd: 0.1 (derivative gain)
+- Min Flow: 0.0 mL/min
+- Max Flow: 500.0 mL/min
+- Update Period: 30 seconds
+- Max Measurement Age: 120 seconds
+
+**Control Logic:**
+```python
+# Direct mode: lower DO → more air
+error = current_DO - setpoint
+output = PID(error)
+flow = clamp(output, min_flow, max_flow)
+```
+
+**Safety Features:**
+- Automatic shutoff if measurement stale/missing
+- Flow clamping to configured limits
+- Graceful stop on deactivation (flow → 0)
+- Exception handling with logging
+
+**Dependencies:**
+- simple-pid (auto-installed on import)
+
+**Compatibility:**
+- Tested with Hamilton ARC DO probes
+- Tested with Alicat MC/MQ series MFCs
+- Mycodo >= 8.0.0
+
+**Logging Output Example:**
+```
+INFO - DO Control: Current=7.85 mg/L, Setpoint=8.00 mg/L, Error=-0.15, Air Flow=45.2 mL/min
+DEBUG - PID Components: P=-1.50, I=-0.08, D=-0.02
+```
+
+**Use Cases:**
+- Bioreactor DO control
+- Fermenter oxygen management
+- Aquaculture DO regulation
+- Any application requiring air/O2-based DO control
+
+**Notes:**
+- Air/O2 addition raises DO
+- Gas transfer is slower than pH response
+- Requires adequate sparging/mixing for efficiency
+- Can use pure O2 for faster response and higher concentrations
+- Start with default gains and tune based on system response
+- Monitor initially to ensure stable control

--- a/custom_functions/dissolved oxygen controller/README.md
+++ b/custom_functions/dissolved oxygen controller/README.md
@@ -1,0 +1,297 @@
+#### Custom Function: DO Control using Air Mass Flow Controller
+
+Version 1.0
+
+#### About
+
+This Function implements PID-based control for maintaining a dissolved oxygen (DO) setpoint by regulating air flow through an Alicat Mass Flow Controller. The controller automatically adjusts air/O2 dosing to keep DO stable in bioreactors, fermenters, or aquaculture systems.
+
+Air increases DO, so the controller uses **direct** control logic: when DO is too low, it increases air flow; when DO is at or above setpoint, it reduces flow.
+
+#### Features
+
+- **PID-based Control** - Smooth, precise DO regulation with configurable gains
+- **Safety Limits** - Min/max flow limits prevent over-aeration
+- **Measurement Timeout** - Stops air flow if DO sensor fails or becomes stale
+- **Real-time Logging** - Detailed debug output showing PID components
+- **Integration Ready** - Works seamlessly with Hamilton DO probes and Alicat MFCs
+
+#### Requirements
+
+- Mycodo >= 8.0.0
+- DO sensor configured as Mycodo Input (e.g., Hamilton DO Probe)
+- Alicat MFC configured as Mycodo Output (for air/O2)
+- Python package: `simple-pid` (auto-installed on import)
+
+#### Hardware Setup
+
+1. **DO Sensor:**
+   - Install and configure DO probe (e.g., Hamilton ARC DO)
+   - Ensure probe is calibrated
+   - Add as Input in Mycodo and verify readings
+
+2. **Air Mass Flow Controller:**
+   - Connect Alicat MFC to air/O2 source
+   - Configure as Output in Mycodo using `alicat_mfc_output.py`
+   - Verify manual control works before enabling PID
+
+3. **System Integration:**
+   - Plumb air line into bioreactor/fermenter
+   - Use sparger or diffuser for efficient gas transfer
+   - Ensure adequate mixing for oxygen dissolution
+
+#### Software Setup
+
+1. **Import Function:**
+   - Navigate to `[Gear Icon] → Configure → Custom Functions`
+   - Click "Import Custom Function"
+   - Upload `do_control_air_mfc.py`
+
+2. **Add Function:**
+   - Go to `Setup → Function`
+   - Select "DO Control (Air MFC)"
+   - Configure (see Configuration section below)
+
+3. **Activate:**
+   - Click "Activate" to start PID control
+   - Monitor in Dashboard and logs
+
+#### Configuration Options
+
+##### Measurement Settings
+| Option | Description | Default |
+|--------|-------------|---------|
+| DO Measurement | Select DO sensor input | (required) |
+| Max Age (seconds) | Stop if measurement older than this | 120 |
+
+##### Output Settings
+| Option | Description | Default |
+|--------|-------------|---------|
+| Air Mass Flow Controller | Select Alicat MFC output | (required) |
+
+##### Control Settings
+| Option | Description | Default |
+|--------|-------------|---------|
+| DO Setpoint (mg/L) | Target DO value to maintain | 8.0 |
+| Period (seconds) | How often to update controller | 30.0 |
+
+##### PID Gains
+| Option | Description | Default |
+|--------|-------------|---------|
+| Kp (Proportional) | Immediate response to error | 10.0 |
+| Ki (Integral) | Eliminates steady-state error | 0.5 |
+| Kd (Derivative) | Dampens oscillations | 0.1 |
+
+##### Flow Limits
+| Option | Description | Default |
+|--------|-------------|---------|
+| Minimum Air Flow (mL/min) | Lower flow limit | 0.0 |
+| Maximum Air Flow (mL/min) | Upper flow limit (safety) | 500.0 |
+
+#### PID Tuning Guide
+
+**Default values work for most applications**, but you may need to tune for your specific system:
+
+**Understanding PID Gains:**
+- **Kp (Proportional):** Immediate response to current error
+  - Higher Kp = faster response but more oscillation
+  - Lower Kp = slower response but more stable
+  
+- **Ki (Integral):** Eliminates steady-state error over time
+  - Higher Ki = faster correction of persistent errors
+  - Lower Ki = slower correction, more stable
+  
+- **Kd (Derivative):** Dampens oscillations and overshoots
+  - Higher Kd = more damping, less overshoot
+  - Lower Kd = less damping, more oscillation
+
+**Tuning Process:**
+
+1. **Start Conservative:**
+   - Use defaults: Kp=10.0, Ki=0.5, Kd=0.1
+   - Set max flow to safe value for your system
+
+2. **Observe Response:**
+   - Watch DO graph for 30-60 minutes
+   - Check logs for PID output values
+
+3. **Adjust Incrementally:**
+   - Too slow? → Increase Kp by 20-50%
+   - Oscillating? → Decrease Kp or increase Kd
+   - Offset from setpoint? → Increase Ki
+   - Overshoots badly? → Increase Kd
+
+**Example Configurations:**
+
+**Bioreactor (High Sensitivity):**
+```
+DO Setpoint: 8.5 mg/L
+Kp: 15.0, Ki: 1.0, Kd: 0.2
+Max Air: 1000 mL/min
+Period: 15s
+```
+
+**Fermenter (Moderate):**
+```
+DO Setpoint: 6.0 mg/L
+Kp: 8.0, Ki: 0.3, Kd: 0.05
+Max Air: 500 mL/min
+Period: 30s
+```
+
+**Aquaculture (Conservative):**
+```
+DO Setpoint: 7.0 mg/L
+Kp: 5.0, Ki: 0.2, Kd: 0.05
+Max Air: 200 mL/min
+Period: 60s
+```
+
+#### Safety Features
+
+1. **Measurement Timeout:**
+   - If DO reading is older than "Max Age", flow stops
+   - Prevents runaway aeration if sensor fails
+
+2. **Flow Limits:**
+   - Hard limits on min/max prevent over-aeration
+   - PID output is clamped within bounds
+
+3. **Graceful Shutdown:**
+   - When deactivated, air flow set to 0
+   - No runaway aeration
+
+4. **Error Handling:**
+   - Missing measurements trigger flow shutdown
+   - All errors logged for debugging
+
+#### Monitoring
+
+**View Controller Status:**
+- Check `More → Daemon Log` for detailed output:
+```
+DO Control: Current=7.85 mg/L, Setpoint=8.00 mg/L, Error=-0.15, Air Flow=45.2 mL/min
+  PID Components: P=-1.50, I=-0.08, D=-0.02
+```
+
+**Dashboard Widgets:**
+Create graphs to visualize:
+- DO measurement over time
+- Air flow rate over time
+- Both on same graph to see relationship
+
+**Alerts:**
+Create conditionals for:
+- DO out of acceptable range
+- Air flow at maximum (sustained)
+- DO sensor inactive/stale
+
+#### Troubleshooting
+
+**Controller oscillates around setpoint:**
+- Decrease Kp (e.g., 10.0 → 5.0)
+- Increase Kd (e.g., 0.1 → 0.2)
+- Increase update period (e.g., 30s → 45s)
+
+**Slow to reach setpoint:**
+- Increase Kp (e.g., 10.0 → 15.0)
+- Increase Ki (e.g., 0.5 → 1.0)
+
+**Persistent offset from setpoint:**
+- Increase Ki (e.g., 0.5 → 1.0)
+- Verify air flow is sufficient (not at max limit)
+
+**"No measurement available" errors:**
+- Check DO sensor is active and reporting
+- Verify max age setting is appropriate
+- Review DO sensor logs for errors
+
+**Flow stays at 0 or max:**
+- Check PID gains aren't too extreme
+- Verify setpoint is achievable with available air flow
+- Ensure min/max flow settings are appropriate
+
+**DO Response Too Slow:**
+- DO transfer is slower than pH (gas transfer limited)
+- Increase Kp for faster response
+- Consider using pure O2 instead of air for faster response
+- Ensure adequate mixing/sparging
+
+#### Technical Details
+
+**Control Algorithm:**
+Uses `simple-pid` library with direct mode:
+```
+error = current_DO - setpoint
+output = Kp * error + Ki * ∫error + Kd * (d/dt)error
+flow_rate = clamp(output, min_flow, max_flow)
+```
+
+**Update Cycle:**
+1. Wait for `period` seconds
+2. Retrieve latest DO measurement
+3. Calculate PID output
+4. Clamp output to min/max flow limits
+5. Send flow setpoint to MFC
+6. Log status
+
+**Thread Safety:**
+- Runs in separate thread managed by Mycodo daemon
+- Uses thread-safe database and output control methods
+
+#### Integration Example
+
+**Complete Bioreactor Setup:**
+
+1. **Inputs:**
+   - Hamilton pH Probe → pH readings
+   - Hamilton DO Probe → DO readings
+   - Temperature sensor → temp monitoring
+
+2. **Outputs:**
+   - Alicat MFC #1 → CO2 for pH control
+   - Alicat MFC #2 → Air for DO control
+
+3. **Functions:**
+   - pH Control (CO2 MFC) → companion function
+   - DO Control (Air MFC) → this function
+
+4. **Dashboard:**
+   - Line graph: pH + CO2 flow
+   - Line graph: DO + Air flow
+   - Gauges: Current pH, current DO
+
+#### Physical Considerations
+
+**Gas Transfer Efficiency:**
+- Use fine bubble spargers for maximum transfer
+- Higher pressure increases dissolution rate
+- Temperature affects O2 solubility
+- Consider pure O2 for high-demand applications
+
+**System Design:**
+- Air flow rate depends on vessel volume and O2 consumption
+- Typical ranges: 0.1-2.0 VVM (volumes per volume per minute)
+- Ensure adequate headspace pressure relief
+- Monitor for excessive foaming
+
+#### Related Modules
+
+- **Hamilton DO Probe Input** - DO sensor readings
+- **Alicat MFC Output** - Air/O2 flow control
+- **pH Control (CO2 MFC)** - Companion function for pH
+- **Temperature Control** - Complete bioreactor control
+
+#### License
+
+GPL v3 (consistent with Mycodo)
+
+#### Support
+
+For issues or questions:
+- Review Mycodo daemon logs for PID output
+- Check DO sensor is working correctly
+- Verify Air MFC responds to manual commands
+- Start with conservative PID gains and tune gradually
+- Consider gas transfer limitations in tuning
+- Post to Mycodo forums or GitHub issues

--- a/custom_functions/dissolved oxygen controller/do_control_air_bangbang.py
+++ b/custom_functions/dissolved oxygen controller/do_control_air_bangbang.py
@@ -1,0 +1,301 @@
+# coding=utf-8
+#
+#  do_control_air_bangbang.py - Simple Bang-Bang DO Control using Air MFC
+#
+#  This custom function implements simple hysteretic (bang-bang) control for DO
+#  by regulating air flow through an Alicat Mass Flow Controller.
+#  Simpler than PID - easier to understand and tune.
+#
+import time
+
+from flask_babel import lazy_gettext
+
+from mycodo.databases.models import CustomController
+from mycodo.functions.base_function import AbstractFunction
+from mycodo.mycodo_client import DaemonControl
+from mycodo.utils.constraints_pass import constraints_pass_positive_value
+from mycodo.utils.constraints_pass import constraints_pass_positive_or_zero_value
+from mycodo.utils.database import db_retrieve_table_daemon
+
+FUNCTION_INFORMATION = {
+    'function_name_unique': 'do_control_air_bangbang',
+    'function_name': 'DO Control Bang-Bang (Air MFC)',
+    'function_name_short': 'DO Bang-Bang Air',
+
+    'message': 'Simple bang-bang (hysteretic) controller for dissolved oxygen using air mass flow controller. '
+               'Much simpler than PID - uses high/low flow rates based on DO thresholds. '
+               'When DO drops below (setpoint - hysteresis), air flow increases to high rate. '
+               'When DO rises above (setpoint + hysteresis), air flow reduces to low rate. '
+               'Easy to understand and tune, excellent for systems that don\'t need precise control.',
+
+    'options_enabled': [
+        'custom_options'
+    ],
+    'options_disabled': [
+        'measurements_select',
+        'measurements_configure'
+    ],
+
+    'custom_options': [
+        {
+            'type': 'message',
+            'default_value': '<strong>Measurement Settings</strong>'
+        },
+        {
+            'id': 'measurement',
+            'type': 'select_measurement',
+            'default_value': '',
+            'required': True,
+            'options_select': [
+                'Input',
+                'Function'
+            ],
+            'name': lazy_gettext('DO Measurement'),
+            'phrase': 'Select the dissolved oxygen sensor input'
+        },
+        {
+            'id': 'measurement_max_age',
+            'type': 'integer',
+            'default_value': 120,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('Max Age (seconds)'),
+            'phrase': 'Maximum age of DO measurement before controller stops'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>Output Settings</strong>'
+        },
+        {
+            'id': 'output',
+            'type': 'select_measurement_channel',
+            'default_value': '',
+            'required': True,
+            'options_select': [
+                'Output_Channels_Measurements',
+            ],
+            'name': lazy_gettext('Air Mass Flow Controller'),
+            'phrase': 'Select the Alicat MFC output for air'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>Control Settings</strong>'
+        },
+        {
+            'id': 'setpoint',
+            'type': 'float',
+            'default_value': 8.0,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('DO Setpoint (mg/L)'),
+            'phrase': 'Target dissolved oxygen value to maintain'
+        },
+        {
+            'id': 'hysteresis',
+            'type': 'float',
+            'default_value': 0.5,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('Hysteresis (mg/L)'),
+            'phrase': 'Control band (+/- around setpoint). Larger = less frequent switching'
+        },
+        {
+            'id': 'period',
+            'type': 'float',
+            'default_value': 15.0,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('Period (seconds)'),
+            'phrase': 'How often to check and update the controller'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>Flow Rate Settings (mL/min)</strong>'
+        },
+        {
+            'id': 'flow_high',
+            'type': 'float',
+            'default_value': 300.0,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('High Flow Rate'),
+            'phrase': 'Air flow when DO is too low (actively raising)'
+        },
+        {
+            'id': 'flow_maintain',
+            'type': 'float',
+            'default_value': 50.0,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_or_zero_value,
+            'name': lazy_gettext('Maintain Flow Rate'),
+            'phrase': 'Air flow when DO is within range (maintaining)'
+        },
+        {
+            'id': 'flow_low',
+            'type': 'float',
+            'default_value': 0.0,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_or_zero_value,
+            'name': lazy_gettext('Low Flow Rate'),
+            'phrase': 'Air flow when DO is too high (typically 0)'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>Advanced Settings</strong>'
+        },
+        {
+            'id': 'start_offset',
+            'type': 'integer',
+            'default_value': 10,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('Start Offset (seconds)'),
+            'phrase': 'Wait time before starting control loop'
+        }
+    ]
+}
+
+
+class CustomModule(AbstractFunction):
+    """
+    Simple Bang-Bang DO Control using Air Mass Flow Controller
+    """
+    def __init__(self, function, testing=False):
+        super().__init__(function, testing=testing, name=__name__)
+
+        self.timer_loop = time.time()
+        self.control = DaemonControl()
+        self.current_state = None  # Track: 'high', 'maintain', 'low'
+
+        # Initialize custom options
+        self.measurement_device_id = None
+        self.measurement_measurement_id = None
+        self.measurement_max_age = None
+        self.output_device_id = None
+        self.output_measurement_id = None
+        self.output_channel_id = None
+        self.output_channel = None
+        self.setpoint = None
+        self.hysteresis = None
+        self.period = None
+        self.flow_high = None
+        self.flow_maintain = None
+        self.flow_low = None
+        self.start_offset = None
+
+        # Calculated thresholds
+        self.do_upper = None
+        self.do_lower = None
+
+        # Set custom options
+        custom_function = db_retrieve_table_daemon(
+            CustomController, unique_id=self.unique_id)
+        self.setup_custom_options(
+            FUNCTION_INFORMATION['custom_options'], custom_function)
+
+        if not testing:
+            self.try_initialize()
+
+    def initialize(self):
+        """Initialize the controller"""
+        self.output_channel = self.get_output_channel_from_channel_id(
+            self.output_channel_id)
+
+        # Calculate control thresholds
+        self.do_upper = self.setpoint + self.hysteresis
+        self.do_lower = self.setpoint - self.hysteresis
+
+        self.timer_loop = time.time() + self.start_offset
+        self.current_state = None
+
+        self.logger.info(
+            "DO Bang-Bang Control (Air) started: DO Setpoint={:.2f} mg/L, Hysteresis={:.2f}, "
+            "Control Range: {:.2f}-{:.2f} mg/L, Flow Rates: High={} mL/min, Maintain={} mL/min, "
+            "Low={} mL/min, Period={}s".format(
+                self.setpoint, self.hysteresis, self.do_lower, self.do_upper,
+                self.flow_high, self.flow_maintain, self.flow_low, self.period))
+
+    def loop(self):
+        """Main control loop"""
+        if self.timer_loop > time.time():
+            return
+
+        while self.timer_loop < time.time():
+            self.timer_loop += self.period
+
+        if self.output_channel is None:
+            self.logger.error("Cannot run DO controller: Output channel not configured")
+            return
+
+        # Get latest DO measurement
+        last_measurement = self.get_last_measurement(
+            self.measurement_device_id,
+            self.measurement_measurement_id,
+            max_age=self.measurement_max_age)
+
+        if not last_measurement or last_measurement[1] is None:
+            self.logger.error("No DO measurement available. Stopping air flow for safety.")
+            self.set_flow(0.0, "SAFETY_STOP")
+            return
+
+        current_do = last_measurement[1]
+        
+        # Determine desired flow based on DO thresholds
+        new_state = None
+        desired_flow = None
+
+        if current_do < self.do_lower:
+            # DO too low - need high air flow to raise it
+            new_state = 'high'
+            desired_flow = self.flow_high
+        elif current_do > self.do_upper:
+            # DO too high - reduce/stop air flow
+            new_state = 'low'
+            desired_flow = self.flow_low
+        else:
+            # DO within range - maintain with moderate flow
+            new_state = 'maintain'
+            desired_flow = self.flow_maintain
+
+        # Only log state changes
+        if new_state != self.current_state:
+            self.logger.info(
+                f"DO Control state change: {self.current_state} → {new_state} "
+                f"(DO={current_do:.3f} mg/L, Setpoint={self.setpoint:.2f} mg/L, "
+                f"Range={self.do_lower:.2f}-{self.do_upper:.2f} mg/L, "
+                f"Setting flow to {desired_flow} mL/min)")
+            self.current_state = new_state
+        else:
+            # Log current status at debug level
+            self.logger.debug(
+                f"DO Control: State={new_state}, DO={current_do:.3f} mg/L, "
+                f"Setpoint={self.setpoint:.2f} mg/L, Flow={desired_flow} mL/min")
+
+        # Set the flow rate
+        self.set_flow(desired_flow, new_state)
+
+    def set_flow(self, flow_rate, state):
+        """Helper function to set MFC flow rate"""
+        self.control.output_on(
+            self.output_device_id,
+            output_type='value',
+            amount=flow_rate,
+            output_channel=self.output_channel)
+
+    def stop_function(self):
+        """Called when function is deactivated - stop air flow"""
+        self.logger.info("DO Bang-Bang Control stopping - setting air flow to 0")
+        if self.output_channel is not None:
+            self.set_flow(0.0, "STOPPED")

--- a/custom_functions/dissolved oxygen controller/do_control_air_mfc.py
+++ b/custom_functions/dissolved oxygen controller/do_control_air_mfc.py
@@ -1,0 +1,326 @@
+# coding=utf-8
+#
+#  do_control_air_mfc.py - Dissolved Oxygen Control using Air Mass Flow Controller
+#
+#  This custom function implements PID control for maintaining DO setpoint
+#  by regulating air flow through an Alicat Mass Flow Controller.
+#
+import time
+
+from flask_babel import lazy_gettext
+
+from mycodo.databases.models import CustomController
+from mycodo.functions.base_function import AbstractFunction
+from mycodo.mycodo_client import DaemonControl
+from mycodo.utils.constraints_pass import constraints_pass_positive_value
+from mycodo.utils.database import db_retrieve_table_daemon
+from mycodo.utils.pid_controller_default import PIDControl
+
+FUNCTION_INFORMATION = {
+    'function_name_unique': 'do_control_air_mfc',
+    'function_name': 'DO Control (Air MFC)',
+    'function_name_short': 'DO Control Air',
+
+    'message': 'PID controller for maintaining dissolved oxygen (DO) setpoint by regulating air flow through a '
+               'mass flow controller. The controller raises DO by increasing air flow. Includes configurable '
+               'min/max flow limits to prevent over-aeration and ensure safe operation. Select a DO input, '
+               'a mass flow controller output, and configure PID gains and flow limits.',
+
+    'options_enabled': [
+        'custom_options'
+    ],
+    'options_disabled': [
+        'measurements_select',
+        'measurements_configure'
+    ],
+
+    'custom_options': [
+        {
+            'type': 'message',
+            'default_value': '<strong>Measurement Settings</strong>'
+        },
+        {
+            'id': 'measurement',
+            'type': 'select_measurement',
+            'default_value': '',
+            'required': True,
+            'options_select': [
+                'Input',
+                'Function'
+            ],
+            'name': lazy_gettext('DO Measurement'),
+            'phrase': 'Select the dissolved oxygen sensor input'
+        },
+        {
+            'id': 'measurement_max_age',
+            'type': 'integer',
+            'default_value': 120,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('Max Age (seconds)'),
+            'phrase': 'Maximum age of DO measurement before controller stops'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>Output Settings</strong>'
+        },
+        {
+            'id': 'output',
+            'type': 'select_measurement_channel',
+            'default_value': '',
+            'required': True,
+            'options_select': [
+                'Output_Channels_Measurements',
+            ],
+            'name': lazy_gettext('Air Mass Flow Controller'),
+            'phrase': 'Select the Alicat MFC output for air'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>Control Settings</strong>'
+        },
+        {
+            'id': 'setpoint',
+            'type': 'float',
+            'default_value': 8.0,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('DO Setpoint (mg/L)'),
+            'phrase': 'Target dissolved oxygen value to maintain'
+        },
+        {
+            'id': 'period',
+            'type': 'float',
+            'default_value': 30.0,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('Period (seconds)'),
+            'phrase': 'How often to update the controller'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>PID Gains</strong>'
+        },
+        {
+            'id': 'kp',
+            'type': 'float',
+            'default_value': 10.0,
+            'required': True,
+            'name': lazy_gettext('Kp (Proportional Gain)'),
+            'phrase': 'Proportional gain - higher values = stronger response to error'
+        },
+        {
+            'id': 'ki',
+            'type': 'float',
+            'default_value': 0.5,
+            'required': True,
+            'name': lazy_gettext('Ki (Integral Gain)'),
+            'phrase': 'Integral gain - eliminates steady-state error over time'
+        },
+        {
+            'id': 'kd',
+            'type': 'float',
+            'default_value': 0.1,
+            'required': True,
+            'name': lazy_gettext('Kd (Derivative Gain)'),
+            'phrase': 'Derivative gain - dampens oscillations and overshoots'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>Flow Limits (mL/min)</strong>'
+        },
+        {
+            'id': 'min_flow',
+            'type': 'float',
+            'default_value': 0.0,
+            'required': True,
+            'name': lazy_gettext('Minimum Air Flow'),
+            'phrase': 'Minimum flow rate in mL/min (typically 0)'
+        },
+        {
+            'id': 'max_flow',
+            'type': 'float',
+            'default_value': 500.0,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('Maximum Air Flow'),
+            'phrase': 'Maximum safe flow rate in mL/min'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>Advanced Settings</strong>'
+        },
+        {
+            'id': 'direction',
+            'type': 'select',
+            'default_value': 'raise',
+            'required': True,
+            'options_select': [
+                ('raise', 'Raise (Air increases DO)'),
+                ('lower', 'Lower (unlikely for air)')
+            ],
+            'name': lazy_gettext('Direction'),
+            'phrase': 'Direction of control - air normally raises DO'
+        },
+        {
+            'id': 'start_offset',
+            'type': 'integer',
+            'default_value': 10,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('Start Offset (seconds)'),
+            'phrase': 'Wait time before starting control loop'
+        }
+    ]
+}
+
+
+class CustomModule(AbstractFunction):
+    """
+    Dissolved Oxygen Control using Air Mass Flow Controller
+    """
+    def __init__(self, function, testing=False):
+        super().__init__(function, testing=testing, name=__name__)
+
+        self.timer_loop = time.time()
+        self.control = DaemonControl()
+        self.pid_controller = None
+
+        # Initialize custom options
+        self.measurement_device_id = None
+        self.measurement_measurement_id = None
+        self.measurement_max_age = None
+        self.output_device_id = None
+        self.output_measurement_id = None
+        self.output_channel_id = None
+        self.output_channel = None
+        self.setpoint = None
+        self.period = None
+        self.kp = None
+        self.ki = None
+        self.kd = None
+        self.min_flow = None
+        self.max_flow = None
+        self.direction = None
+        self.start_offset = None
+
+        # Set custom options
+        custom_function = db_retrieve_table_daemon(
+            CustomController, unique_id=self.unique_id)
+        self.setup_custom_options(
+            FUNCTION_INFORMATION['custom_options'], custom_function)
+
+        if not testing:
+            self.try_initialize()
+
+    def initialize(self):
+        """Initialize the PID controller"""
+        self.output_channel = self.get_output_channel_from_channel_id(
+            self.output_channel_id)
+
+        # Initialize PID controller using Mycodo's built-in PIDControl
+        # For raising DO with air, we want PID to output positive values when DO < setpoint
+        if self.direction == 'raise':
+            # Direct mode: output increases when measurement is below setpoint
+            self.pid_controller = PIDControl(
+                self.logger, self.setpoint, self.kp, self.ki, self.kd,
+                direction='raise',
+                band=0,
+                integrator_min=self.min_flow,
+                integrator_max=self.max_flow
+            )
+        else:
+            # Reverse mode: negate gains so output increases when measurement is above setpoint
+            self.pid_controller = PIDControl(
+                self.logger, self.setpoint, -self.kp, -self.ki, -self.kd,
+                direction='lower',
+                band=0,
+                integrator_min=self.min_flow,
+                integrator_max=self.max_flow
+            )
+
+        self.timer_loop = time.time() + self.start_offset
+
+        self.logger.info(
+            "DO Control (Air) started: DO Setpoint={:.2f} mg/L, Kp={}, Ki={}, Kd={}, "
+            "Flow Limits: {}-{} mL/min, Period={}s, Direction={}".format(
+                self.setpoint, self.kp, self.ki, self.kd,
+                self.min_flow, self.max_flow, self.period, self.direction))
+
+    def loop(self):
+        """Main control loop"""
+        if self.timer_loop > time.time():
+            return
+
+        while self.timer_loop < time.time():
+            self.timer_loop += self.period
+
+        if self.output_channel is None:
+            self.logger.error("Cannot run DO controller: Output channel not configured")
+            return
+
+        # Get latest DO measurement
+        last_measurement = self.get_last_measurement(
+            self.measurement_device_id,
+            self.measurement_measurement_id,
+            max_age=self.measurement_max_age)
+
+        if not last_measurement or last_measurement[1] is None:
+            self.logger.error("No DO measurement available. Stopping air flow for safety.")
+            self.control.output_on(
+                self.output_device_id,
+                output_type='value',
+                amount=0.0,
+                output_channel=self.output_channel)
+            return
+
+        current_do = last_measurement[1]
+        
+        # Calculate PID output
+        self.pid_controller.update_pid_output(current_do)
+        air_flow = self.pid_controller.control_variable
+
+        # Ensure flow is within bounds
+        air_flow = max(self.min_flow, min(self.max_flow, air_flow))
+
+        # Send flow setpoint to MFC
+        self.control.output_on(
+            self.output_device_id,
+            output_type='value',
+            amount=air_flow,
+            output_channel=self.output_channel)
+
+        # Get PID components for logging
+        p = self.pid_controller.P_value if self.pid_controller.P_value else 0
+        i = self.pid_controller.I_value if self.pid_controller.I_value else 0
+        d = self.pid_controller.D_value if self.pid_controller.D_value else 0
+
+        self.logger.debug(
+            f"DO Control: Current={current_do:.3f} mg/L, Setpoint={self.setpoint:.3f} mg/L, "
+            f"Error={current_do - self.setpoint:.3f}, Air Flow={air_flow:.2f} mL/min, "
+            f"PID(P={p:.2f}, I={i:.2f}, D={d:.2f})")
+
+    def stop_function(self):
+        """Called when function is deactivated - stop air flow"""
+        self.logger.info("DO Control stopping - setting air flow to 0")
+        if self.output_channel is not None:
+            self.control.output_on(
+                self.output_device_id,
+                output_type='value',
+                amount=0.0,
+                output_channel=self.output_channel)

--- a/custom_functions/ph controller/CHANGELOG.md
+++ b/custom_functions/ph controller/CHANGELOG.md
@@ -1,0 +1,65 @@
+## Changelog - pH Control (CO2 MFC)
+
+### Version 1.0 (2025-01-14)
+
+**Initial Release**
+
+**Features:**
+- PID-based pH control using CO2 mass flow controller
+- Reverse control logic (CO2 lowers pH)
+- Configurable Kp, Ki, Kd gains for tuning
+- Min/max flow rate limits for safety
+- Measurement timeout protection (stops flow if sensor fails)
+- Real-time logging of PID components and control variables
+- Compatible with any Mycodo Input providing pH measurements
+- Compatible with Alicat MFC outputs
+
+**Default Settings:**
+- pH Setpoint: 7.0
+- Kp: 1.0 (proportional gain)
+- Ki: 0.1 (integral gain)
+- Kd: 0.05 (derivative gain)
+- Min Flow: 0.0 mL/min
+- Max Flow: 100.0 mL/min
+- Update Period: 30 seconds
+- Max Measurement Age: 120 seconds
+
+**Control Logic:**
+```python
+# Reverse mode: higher pH → more CO2
+error = setpoint - current_pH
+output = PID(error)
+flow = clamp(output, min_flow, max_flow)
+```
+
+**Safety Features:**
+- Automatic shutoff if measurement stale/missing
+- Flow clamping to configured limits
+- Graceful stop on deactivation (flow → 0)
+- Exception handling with logging
+
+**Dependencies:**
+- simple-pid (auto-installed on import)
+
+**Compatibility:**
+- Tested with Hamilton ARC pH probes
+- Tested with Alicat MC/MQ series MFCs
+- Mycodo >= 8.0.0
+
+**Logging Output Example:**
+```
+INFO - pH Control: Current=7.23, Setpoint=7.00, Error=0.23, CO2 Flow=15.3 mL/min
+DEBUG - PID Components: P=0.23, I=0.05, D=0.02
+```
+
+**Use Cases:**
+- Bioreactor pH control
+- Fermenter pH regulation
+- Aquaculture pH management
+- Any application requiring CO2-based pH control
+
+**Notes:**
+- CO2 addition lowers pH (acid effect)
+- Requires adequate mixing for CO2 dissolution
+- Start with default gains and tune based on system response
+- Monitor initially to ensure stable control

--- a/custom_functions/ph controller/README.md
+++ b/custom_functions/ph controller/README.md
@@ -1,0 +1,268 @@
+#### Custom Function: pH Control using CO2 Mass Flow Controller
+
+Version 1.0
+
+#### About
+
+This Function implements PID-based control for maintaining a pH setpoint by regulating CO2 flow through an Alicat Mass Flow Controller. The controller automatically adjusts CO2 dosing to keep pH stable in bioreactors, fermenters, or aquaculture systems.
+
+CO2 lowers pH, so the controller uses **reverse** control logic: when pH is too high, it increases CO2 flow; when pH is at or below setpoint, it reduces flow.
+
+#### Features
+
+- **PID-based Control** - Smooth, precise pH regulation with configurable gains
+- **Safety Limits** - Min/max flow limits prevent over-dosing
+- **Measurement Timeout** - Stops CO2 flow if pH sensor fails or becomes stale
+- **Real-time Logging** - Detailed debug output showing PID components
+- **Integration Ready** - Works seamlessly with Hamilton pH probes and Alicat MFCs
+
+#### Requirements
+
+- Mycodo >= 8.0.0
+- pH sensor configured as Mycodo Input (e.g., Hamilton pH Probe)
+- Alicat MFC configured as Mycodo Output (for CO2)
+- Python package: `simple-pid` (auto-installed on import)
+
+#### Hardware Setup
+
+1. **pH Sensor:**
+   - Install and configure pH probe (e.g., Hamilton ARC pH)
+   - Ensure probe is calibrated
+   - Add as Input in Mycodo and verify readings
+
+2. **CO2 Mass Flow Controller:**
+   - Connect Alicat MFC to CO2 source
+   - Configure as Output in Mycodo using `alicat_mfc_output.py`
+   - Verify manual control works before enabling PID
+
+3. **System Integration:**
+   - Plumb CO2 line into bioreactor/fermenter
+   - Ensure adequate mixing for CO2 dissolution
+   - Consider using sparger or diffuser for efficiency
+
+#### Software Setup
+
+1. **Import Function:**
+   - Navigate to `[Gear Icon] → Configure → Custom Functions`
+   - Click "Import Custom Function"
+   - Upload `ph_control_co2_mfc.py`
+
+2. **Add Function:**
+   - Go to `Setup → Function`
+   - Select "pH Control (CO2 MFC)"
+   - Configure (see Configuration section below)
+
+3. **Activate:**
+   - Click "Activate" to start PID control
+   - Monitor in Dashboard and logs
+
+#### Configuration Options
+
+##### Measurement Settings
+| Option | Description | Default |
+|--------|-------------|---------|
+| pH Measurement | Select pH sensor input | (required) |
+| Max Age (seconds) | Stop if measurement older than this | 120 |
+
+##### Output Settings
+| Option | Description | Default |
+|--------|-------------|---------|
+| CO2 Mass Flow Controller | Select Alicat MFC output | (required) |
+
+##### Control Settings
+| Option | Description | Default |
+|--------|-------------|---------|
+| pH Setpoint | Target pH value to maintain | 7.0 |
+| Period (seconds) | How often to update controller | 30.0 |
+
+##### PID Gains
+| Option | Description | Default |
+|--------|-------------|---------|
+| Kp (Proportional) | Immediate response to error | 1.0 |
+| Ki (Integral) | Eliminates steady-state error | 0.1 |
+| Kd (Derivative) | Dampens oscillations | 0.05 |
+
+##### Flow Limits
+| Option | Description | Default |
+|--------|-------------|---------|
+| Minimum CO2 Flow (mL/min) | Lower flow limit | 0.0 |
+| Maximum CO2 Flow (mL/min) | Upper flow limit (safety) | 100.0 |
+
+#### PID Tuning Guide
+
+**Default values work for most applications**, but you may need to tune for your specific system:
+
+**Understanding PID Gains:**
+- **Kp (Proportional):** Immediate response to current error
+  - Higher Kp = faster response but more oscillation
+  - Lower Kp = slower response but more stable
+  
+- **Ki (Integral):** Eliminates steady-state error over time
+  - Higher Ki = faster correction of persistent errors
+  - Lower Ki = slower correction, more stable
+  
+- **Kd (Derivative):** Dampens oscillations and overshoots
+  - Higher Kd = more damping, less overshoot
+  - Lower Kd = less damping, more oscillation
+
+**Tuning Process:**
+
+1. **Start Conservative:**
+   - Use defaults: Kp=1.0, Ki=0.1, Kd=0.05
+   - Set max flow to safe value for your system
+
+2. **Observe Response:**
+   - Watch pH graph for 30-60 minutes
+   - Check logs for PID output values
+
+3. **Adjust Incrementally:**
+   - Too slow? → Increase Kp by 20-50%
+   - Oscillating? → Decrease Kp or increase Kd
+   - Offset from setpoint? → Increase Ki
+   - Overshoots badly? → Increase Kd
+
+**Example Configurations:**
+
+**Bioreactor (Aggressive):**
+```
+pH Setpoint: 7.0
+Kp: 2.0, Ki: 0.3, Kd: 0.1
+Max CO2: 50 mL/min
+Period: 20s
+```
+
+**Aquaculture (Conservative):**
+```
+pH Setpoint: 7.5
+Kp: 0.5, Ki: 0.05, Kd: 0.02
+Max CO2: 30 mL/min
+Period: 60s
+```
+
+#### Safety Features
+
+1. **Measurement Timeout:**
+   - If pH reading is older than "Max Age", flow stops
+   - Prevents runaway dosing if sensor fails
+
+2. **Flow Limits:**
+   - Hard limits on min/max prevent over-dosing
+   - PID output is clamped within bounds
+
+3. **Graceful Shutdown:**
+   - When deactivated, CO2 flow set to 0
+   - No runaway dosing
+
+4. **Error Handling:**
+   - Missing measurements trigger flow shutdown
+   - All errors logged for debugging
+
+#### Monitoring
+
+**View Controller Status:**
+- Check `More → Daemon Log` for detailed output:
+```
+pH Control: Current=7.23, Setpoint=7.00, Error=0.23, CO2 Flow=15.3 mL/min
+  PID Components: P=0.23, I=0.05, D=0.02
+```
+
+**Dashboard Widgets:**
+Create graphs to visualize:
+- pH measurement over time
+- CO2 flow rate over time
+- Both on same graph to see relationship
+
+**Alerts:**
+Create conditionals for:
+- pH out of acceptable range
+- CO2 flow at maximum (sustained)
+- pH sensor inactive/stale
+
+#### Troubleshooting
+
+**Controller oscillates around setpoint:**
+- Decrease Kp (e.g., 1.0 → 0.5)
+- Increase Kd (e.g., 0.05 → 0.1)
+- Increase update period (e.g., 30s → 45s)
+
+**Slow to reach setpoint:**
+- Increase Kp (e.g., 1.0 → 1.5)
+- Increase Ki (e.g., 0.1 → 0.2)
+
+**Persistent offset from setpoint:**
+- Increase Ki (e.g., 0.1 → 0.3)
+- Verify CO2 flow is sufficient (not at max limit)
+
+**"No measurement available" errors:**
+- Check pH sensor is active and reporting
+- Verify max age setting is appropriate
+- Review pH sensor logs for errors
+
+**Flow stays at 0 or max:**
+- Check PID gains aren't too extreme
+- Verify setpoint is achievable with available CO2 flow
+- Ensure min/max flow settings are appropriate
+
+#### Technical Details
+
+**Control Algorithm:**
+Uses `simple-pid` library with reverse mode:
+```
+error = setpoint - current_pH
+output = Kp * error + Ki * ∫error + Kd * (d/dt)error
+flow_rate = clamp(output, min_flow, max_flow)
+```
+
+**Update Cycle:**
+1. Wait for `period` seconds
+2. Retrieve latest pH measurement
+3. Calculate PID output
+4. Clamp output to min/max flow limits
+5. Send flow setpoint to MFC
+6. Log status
+
+**Thread Safety:**
+- Runs in separate thread managed by Mycodo daemon
+- Uses thread-safe database and output control methods
+
+#### Integration Example
+
+**Complete Bioreactor Setup:**
+
+1. **Inputs:**
+   - Hamilton pH Probe → pH readings
+   - Hamilton DO Probe → DO readings
+   - Temperature sensor → temp monitoring
+
+2. **Outputs:**
+   - Alicat MFC #1 → CO2 for pH control
+   - Alicat MFC #2 → Air for DO control
+
+3. **Functions:**
+   - pH Control (CO2 MFC) → this function
+   - DO Control (Air MFC) → companion function
+
+4. **Dashboard:**
+   - Line graph: pH + CO2 flow
+   - Line graph: DO + Air flow
+   - Gauges: Current pH, current DO
+
+#### Related Modules
+
+- **Hamilton pH Probe Input** - pH sensor readings
+- **Alicat MFC Output** - CO2 flow control
+- **DO Control (Air MFC)** - Companion function for DO
+- **pH Control (Dual Output)** - Alternative using CO2 + base
+
+#### License
+
+GPL v3 (consistent with Mycodo)
+
+#### Support
+
+For issues or questions:
+- Review Mycodo daemon logs for PID output
+- Check pH sensor is working correctly
+- Verify CO2 MFC responds to manual commands
+- Start with conservative PID gains and tune gradually
+- Post to Mycodo forums or GitHub issues

--- a/custom_functions/ph controller/ph_control_co2_bangbang.py
+++ b/custom_functions/ph controller/ph_control_co2_bangbang.py
@@ -1,0 +1,300 @@
+# coding=utf-8
+#
+#  ph_control_co2_bangbang.py - Simple Bang-Bang pH Control using CO2 MFC
+#
+#  This custom function implements simple hysteretic (bang-bang) control for pH
+#  by regulating CO2 flow through an Alicat Mass Flow Controller.
+#  Simpler than PID - easier to understand and tune.
+#
+import time
+
+from flask_babel import lazy_gettext
+
+from mycodo.databases.models import CustomController
+from mycodo.functions.base_function import AbstractFunction
+from mycodo.mycodo_client import DaemonControl
+from mycodo.utils.constraints_pass import constraints_pass_positive_value
+from mycodo.utils.constraints_pass import constraints_pass_positive_or_zero_value
+from mycodo.utils.database import db_retrieve_table_daemon
+
+FUNCTION_INFORMATION = {
+    'function_name_unique': 'ph_control_co2_bangbang',
+    'function_name': 'pH Control Bang-Bang (CO2 MFC)',
+    'function_name_short': 'pH Bang-Bang CO2',
+
+    'message': 'Simple bang-bang (hysteretic) controller for pH using CO2 mass flow controller. '
+               'Much simpler than PID - uses high/low flow rates based on pH thresholds. '
+               'When pH rises above (setpoint + hysteresis), CO2 flow increases to high rate. '
+               'When pH drops below (setpoint - hysteresis), CO2 flow reduces to low rate. '
+               'Easy to understand and tune, excellent for systems that don\'t need precise control.',
+
+    'options_enabled': [
+        'custom_options'
+    ],
+    'options_disabled': [
+        'measurements_select',
+        'measurements_configure'
+    ],
+
+    'custom_options': [
+        {
+            'type': 'message',
+            'default_value': '<strong>Measurement Settings</strong>'
+        },
+        {
+            'id': 'measurement',
+            'type': 'select_measurement',
+            'default_value': '',
+            'required': True,
+            'options_select': [
+                'Input',
+                'Function'
+            ],
+            'name': lazy_gettext('pH Measurement'),
+            'phrase': 'Select the pH sensor input'
+        },
+        {
+            'id': 'measurement_max_age',
+            'type': 'integer',
+            'default_value': 120,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('Max Age (seconds)'),
+            'phrase': 'Maximum age of pH measurement before controller stops'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>Output Settings</strong>'
+        },
+        {
+            'id': 'output',
+            'type': 'select_measurement_channel',
+            'default_value': '',
+            'required': True,
+            'options_select': [
+                'Output_Channels_Measurements',
+            ],
+            'name': lazy_gettext('CO2 Mass Flow Controller'),
+            'phrase': 'Select the Alicat MFC output for CO2'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>Control Settings</strong>'
+        },
+        {
+            'id': 'setpoint',
+            'type': 'float',
+            'default_value': 7.0,
+            'required': True,
+            'name': lazy_gettext('pH Setpoint'),
+            'phrase': 'Target pH value to maintain'
+        },
+        {
+            'id': 'hysteresis',
+            'type': 'float',
+            'default_value': 0.2,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('Hysteresis'),
+            'phrase': 'Control band (+/- around setpoint). Larger = less frequent switching'
+        },
+        {
+            'id': 'period',
+            'type': 'float',
+            'default_value': 15.0,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('Period (seconds)'),
+            'phrase': 'How often to check and update the controller'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>Flow Rate Settings (mL/min)</strong>'
+        },
+        {
+            'id': 'flow_high',
+            'type': 'float',
+            'default_value': 50.0,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('High Flow Rate'),
+            'phrase': 'CO2 flow when pH is too high (actively lowering)'
+        },
+        {
+            'id': 'flow_maintain',
+            'type': 'float',
+            'default_value': 10.0,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_or_zero_value,
+            'name': lazy_gettext('Maintain Flow Rate'),
+            'phrase': 'CO2 flow when pH is within range (maintaining)'
+        },
+        {
+            'id': 'flow_low',
+            'type': 'float',
+            'default_value': 0.0,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_or_zero_value,
+            'name': lazy_gettext('Low Flow Rate'),
+            'phrase': 'CO2 flow when pH is too low (typically 0)'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>Advanced Settings</strong>'
+        },
+        {
+            'id': 'start_offset',
+            'type': 'integer',
+            'default_value': 10,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('Start Offset (seconds)'),
+            'phrase': 'Wait time before starting control loop'
+        }
+    ]
+}
+
+
+class CustomModule(AbstractFunction):
+    """
+    Simple Bang-Bang pH Control using CO2 Mass Flow Controller
+    """
+    def __init__(self, function, testing=False):
+        super().__init__(function, testing=testing, name=__name__)
+
+        self.timer_loop = time.time()
+        self.control = DaemonControl()
+        self.current_state = None  # Track: 'high', 'maintain', 'low'
+
+        # Initialize custom options
+        self.measurement_device_id = None
+        self.measurement_measurement_id = None
+        self.measurement_max_age = None
+        self.output_device_id = None
+        self.output_measurement_id = None
+        self.output_channel_id = None
+        self.output_channel = None
+        self.setpoint = None
+        self.hysteresis = None
+        self.period = None
+        self.flow_high = None
+        self.flow_maintain = None
+        self.flow_low = None
+        self.start_offset = None
+
+        # Calculated thresholds
+        self.ph_upper = None
+        self.ph_lower = None
+
+        # Set custom options
+        custom_function = db_retrieve_table_daemon(
+            CustomController, unique_id=self.unique_id)
+        self.setup_custom_options(
+            FUNCTION_INFORMATION['custom_options'], custom_function)
+
+        if not testing:
+            self.try_initialize()
+
+    def initialize(self):
+        """Initialize the controller"""
+        self.output_channel = self.get_output_channel_from_channel_id(
+            self.output_channel_id)
+
+        # Calculate control thresholds
+        self.ph_upper = self.setpoint + self.hysteresis
+        self.ph_lower = self.setpoint - self.hysteresis
+
+        self.timer_loop = time.time() + self.start_offset
+        self.current_state = None
+
+        self.logger.info(
+            "pH Bang-Bang Control (CO2) started: pH Setpoint={:.2f}, Hysteresis={:.2f}, "
+            "Control Range: {:.2f}-{:.2f}, Flow Rates: High={} mL/min, Maintain={} mL/min, "
+            "Low={} mL/min, Period={}s".format(
+                self.setpoint, self.hysteresis, self.ph_lower, self.ph_upper,
+                self.flow_high, self.flow_maintain, self.flow_low, self.period))
+
+    def loop(self):
+        """Main control loop"""
+        if self.timer_loop > time.time():
+            return
+
+        while self.timer_loop < time.time():
+            self.timer_loop += self.period
+
+        if self.output_channel is None:
+            self.logger.error("Cannot run pH controller: Output channel not configured")
+            return
+
+        # Get latest pH measurement
+        last_measurement = self.get_last_measurement(
+            self.measurement_device_id,
+            self.measurement_measurement_id,
+            max_age=self.measurement_max_age)
+
+        if not last_measurement or last_measurement[1] is None:
+            self.logger.error("No pH measurement available. Stopping CO2 flow for safety.")
+            self.set_flow(0.0, "SAFETY_STOP")
+            return
+
+        current_ph = last_measurement[1]
+        
+        # Determine desired flow based on pH thresholds
+        new_state = None
+        desired_flow = None
+
+        if current_ph > self.ph_upper:
+            # pH too high - need high CO2 flow to lower it
+            new_state = 'high'
+            desired_flow = self.flow_high
+        elif current_ph < self.ph_lower:
+            # pH too low - reduce/stop CO2 flow
+            new_state = 'low'
+            desired_flow = self.flow_low
+        else:
+            # pH within range - maintain with low flow
+            new_state = 'maintain'
+            desired_flow = self.flow_maintain
+
+        # Only log state changes
+        if new_state != self.current_state:
+            self.logger.info(
+                f"pH Control state change: {self.current_state} → {new_state} "
+                f"(pH={current_ph:.3f}, Setpoint={self.setpoint:.2f}, "
+                f"Range={self.ph_lower:.2f}-{self.ph_upper:.2f}, "
+                f"Setting flow to {desired_flow} mL/min)")
+            self.current_state = new_state
+        else:
+            # Log current status at debug level
+            self.logger.debug(
+                f"pH Control: State={new_state}, pH={current_ph:.3f}, "
+                f"Setpoint={self.setpoint:.2f}, Flow={desired_flow} mL/min")
+
+        # Set the flow rate
+        self.set_flow(desired_flow, new_state)
+
+    def set_flow(self, flow_rate, state):
+        """Helper function to set MFC flow rate"""
+        self.control.output_on(
+            self.output_device_id,
+            output_type='value',
+            amount=flow_rate,
+            output_channel=self.output_channel)
+
+    def stop_function(self):
+        """Called when function is deactivated - stop CO2 flow"""
+        self.logger.info("pH Bang-Bang Control stopping - setting CO2 flow to 0")
+        if self.output_channel is not None:
+            self.set_flow(0.0, "STOPPED")

--- a/custom_functions/ph controller/ph_control_co2_mfc.py
+++ b/custom_functions/ph controller/ph_control_co2_mfc.py
@@ -1,0 +1,325 @@
+# coding=utf-8
+#
+#  ph_control_co2_mfc.py - pH Control using CO2 Mass Flow Controller
+#
+#  This custom function implements PID control for maintaining pH setpoint
+#  by regulating CO2 flow through an Alicat Mass Flow Controller.
+#
+import time
+
+from flask_babel import lazy_gettext
+
+from mycodo.databases.models import CustomController
+from mycodo.functions.base_function import AbstractFunction
+from mycodo.mycodo_client import DaemonControl
+from mycodo.utils.constraints_pass import constraints_pass_positive_value
+from mycodo.utils.database import db_retrieve_table_daemon
+from mycodo.utils.pid_controller_default import PIDControl
+
+FUNCTION_INFORMATION = {
+    'function_name_unique': 'ph_control_co2_mfc',
+    'function_name': 'pH Control (CO2 MFC)',
+    'function_name_short': 'pH Control CO2',
+
+    'message': 'PID controller for maintaining pH setpoint by regulating CO2 flow through a mass flow controller. '
+               'The controller lowers pH by increasing CO2 flow. Includes configurable min/max flow limits to '
+               'prevent over-dosing and ensure safe operation. Select a pH input, a mass flow controller output, '
+               'and configure PID gains and flow limits.',
+
+    'options_enabled': [
+        'custom_options'
+    ],
+    'options_disabled': [
+        'measurements_select',
+        'measurements_configure'
+    ],
+
+    'custom_options': [
+        {
+            'type': 'message',
+            'default_value': '<strong>Measurement Settings</strong>'
+        },
+        {
+            'id': 'measurement',
+            'type': 'select_measurement',
+            'default_value': '',
+            'required': True,
+            'options_select': [
+                'Input',
+                'Function'
+            ],
+            'name': lazy_gettext('pH Measurement'),
+            'phrase': 'Select the pH sensor input'
+        },
+        {
+            'id': 'measurement_max_age',
+            'type': 'integer',
+            'default_value': 120,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('Max Age (seconds)'),
+            'phrase': 'Maximum age of pH measurement before controller stops'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>Output Settings</strong>'
+        },
+        {
+            'id': 'output',
+            'type': 'select_measurement_channel',
+            'default_value': '',
+            'required': True,
+            'options_select': [
+                'Output_Channels_Measurements',
+            ],
+            'name': lazy_gettext('CO2 Mass Flow Controller'),
+            'phrase': 'Select the Alicat MFC output for CO2'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>Control Settings</strong>'
+        },
+        {
+            'id': 'setpoint',
+            'type': 'float',
+            'default_value': 7.0,
+            'required': True,
+            'name': lazy_gettext('pH Setpoint'),
+            'phrase': 'Target pH value to maintain'
+        },
+        {
+            'id': 'period',
+            'type': 'float',
+            'default_value': 30.0,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('Period (seconds)'),
+            'phrase': 'How often to update the controller'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>PID Gains</strong>'
+        },
+        {
+            'id': 'kp',
+            'type': 'float',
+            'default_value': 1.0,
+            'required': True,
+            'name': lazy_gettext('Kp (Proportional Gain)'),
+            'phrase': 'Proportional gain - higher values = stronger response to error'
+        },
+        {
+            'id': 'ki',
+            'type': 'float',
+            'default_value': 0.1,
+            'required': True,
+            'name': lazy_gettext('Ki (Integral Gain)'),
+            'phrase': 'Integral gain - eliminates steady-state error over time'
+        },
+        {
+            'id': 'kd',
+            'type': 'float',
+            'default_value': 0.05,
+            'required': True,
+            'name': lazy_gettext('Kd (Derivative Gain)'),
+            'phrase': 'Derivative gain - dampens oscillations and overshoots'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>Flow Limits (mL/min)</strong>'
+        },
+        {
+            'id': 'min_flow',
+            'type': 'float',
+            'default_value': 0.0,
+            'required': True,
+            'name': lazy_gettext('Minimum CO2 Flow'),
+            'phrase': 'Minimum flow rate in mL/min (typically 0)'
+        },
+        {
+            'id': 'max_flow',
+            'type': 'float',
+            'default_value': 100.0,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('Maximum CO2 Flow'),
+            'phrase': 'Maximum safe flow rate in mL/min'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>Advanced Settings</strong>'
+        },
+        {
+            'id': 'direction',
+            'type': 'select',
+            'default_value': 'lower',
+            'required': True,
+            'options_select': [
+                ('lower', 'Lower (CO2 decreases pH)'),
+                ('raise', 'Raise (unlikely for CO2)')
+            ],
+            'name': lazy_gettext('Direction'),
+            'phrase': 'Direction of control - CO2 normally lowers pH'
+        },
+        {
+            'id': 'start_offset',
+            'type': 'integer',
+            'default_value': 10,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('Start Offset (seconds)'),
+            'phrase': 'Wait time before starting control loop'
+        }
+    ]
+}
+
+
+class CustomModule(AbstractFunction):
+    """
+    pH Control using CO2 Mass Flow Controller
+    """
+    def __init__(self, function, testing=False):
+        super().__init__(function, testing=testing, name=__name__)
+
+        self.timer_loop = time.time()
+        self.control = DaemonControl()
+        self.pid_controller = None
+
+        # Initialize custom options
+        self.measurement_device_id = None
+        self.measurement_measurement_id = None
+        self.measurement_max_age = None
+        self.output_device_id = None
+        self.output_measurement_id = None
+        self.output_channel_id = None
+        self.output_channel = None
+        self.setpoint = None
+        self.period = None
+        self.kp = None
+        self.ki = None
+        self.kd = None
+        self.min_flow = None
+        self.max_flow = None
+        self.direction = None
+        self.start_offset = None
+
+        # Set custom options
+        custom_function = db_retrieve_table_daemon(
+            CustomController, unique_id=self.unique_id)
+        self.setup_custom_options(
+            FUNCTION_INFORMATION['custom_options'], custom_function)
+
+        if not testing:
+            self.try_initialize()
+
+    def initialize(self):
+        """Initialize the PID controller"""
+        self.output_channel = self.get_output_channel_from_channel_id(
+            self.output_channel_id)
+
+        # Initialize PID controller using Mycodo's built-in PIDControl
+        # For lowering pH with CO2, we want PID to output positive values when pH > setpoint
+        if self.direction == 'lower':
+            # Reverse mode: negate gains so output increases when measurement is above setpoint
+            self.pid_controller = PIDControl(
+                self.logger, self.setpoint, -self.kp, -self.ki, -self.kd,
+                direction='lower',
+                band=0,
+                integrator_min=self.min_flow,
+                integrator_max=self.max_flow
+            )
+        else:
+            # Direct mode: output increases when measurement is below setpoint
+            self.pid_controller = PIDControl(
+                self.logger, self.setpoint, self.kp, self.ki, self.kd,
+                direction='raise',
+                band=0,
+                integrator_min=self.min_flow,
+                integrator_max=self.max_flow
+            )
+
+        self.timer_loop = time.time() + self.start_offset
+
+        self.logger.info(
+            "pH Control (CO2) started: pH Setpoint={:.2f}, Kp={}, Ki={}, Kd={}, "
+            "Flow Limits: {}-{} mL/min, Period={}s, Direction={}".format(
+                self.setpoint, self.kp, self.ki, self.kd,
+                self.min_flow, self.max_flow, self.period, self.direction))
+
+    def loop(self):
+        """Main control loop"""
+        if self.timer_loop > time.time():
+            return
+
+        while self.timer_loop < time.time():
+            self.timer_loop += self.period
+
+        if self.output_channel is None:
+            self.logger.error("Cannot run pH controller: Output channel not configured")
+            return
+
+        # Get latest pH measurement
+        last_measurement = self.get_last_measurement(
+            self.measurement_device_id,
+            self.measurement_measurement_id,
+            max_age=self.measurement_max_age)
+
+        if not last_measurement or last_measurement[1] is None:
+            self.logger.error("No pH measurement available. Stopping CO2 flow for safety.")
+            self.control.output_on(
+                self.output_device_id,
+                output_type='value',
+                amount=0.0,
+                output_channel=self.output_channel)
+            return
+
+        current_ph = last_measurement[1]
+        
+        # Calculate PID output
+        self.pid_controller.update_pid_output(current_ph)
+        co2_flow = self.pid_controller.control_variable
+
+        # Ensure flow is within bounds
+        co2_flow = max(self.min_flow, min(self.max_flow, co2_flow))
+
+        # Send flow setpoint to MFC
+        self.control.output_on(
+            self.output_device_id,
+            output_type='value',
+            amount=co2_flow,
+            output_channel=self.output_channel)
+
+        # Get PID components for logging
+        p = self.pid_controller.P_value if self.pid_controller.P_value else 0
+        i = self.pid_controller.I_value if self.pid_controller.I_value else 0
+        d = self.pid_controller.D_value if self.pid_controller.D_value else 0
+
+        self.logger.debug(
+            f"pH Control: Current={current_ph:.3f}, Setpoint={self.setpoint:.3f}, "
+            f"Error={current_ph - self.setpoint:.3f}, CO2 Flow={co2_flow:.2f} mL/min, "
+            f"PID(P={p:.2f}, I={i:.2f}, D={d:.2f})")
+
+    def stop_function(self):
+        """Called when function is deactivated - stop CO2 flow"""
+        self.logger.info("pH Control stopping - setting CO2 flow to 0")
+        if self.output_channel is not None:
+            self.control.output_on(
+                self.output_device_id,
+                output_type='value',
+                amount=0.0,
+                output_channel=self.output_channel)

--- a/custom_functions/ph controller/ph_control_dual_output.py
+++ b/custom_functions/ph controller/ph_control_dual_output.py
@@ -1,0 +1,564 @@
+# coding=utf-8
+#
+#  ph_control_dual_output.py - pH Control using CO2 MFC and Base Pump
+#
+#  This custom function implements bang-bang control for pH regulation
+#  using a CO2 mass flow controller to lower pH and a base pump to raise pH.
+#  Based on Mycodo's regulate_ph_ec.py but simplified for gas/liquid control.
+#
+import threading
+import time
+
+from flask_babel import lazy_gettext
+
+from mycodo.databases.models import CustomController
+from mycodo.databases.models import SMTP
+from mycodo.functions.base_function import AbstractFunction
+from mycodo.mycodo_client import DaemonControl
+from mycodo.utils.constraints_pass import constraints_pass_positive_value
+from mycodo.utils.database import db_retrieve_table_daemon
+from mycodo.utils.send_data import send_email
+
+FUNCTION_INFORMATION = {
+    'function_name_unique': 'ph_control_dual_output',
+    'function_name': 'pH Control (CO2 MFC + Base Pump)',
+    'function_name_short': 'pH Control Dual',
+
+    'message': 'Regulate pH using a CO2 mass flow controller to lower pH and a base pump to raise pH. '
+               'When pH is too high, CO2 flow increases. When pH is too low, base solution is dosed. '
+               'Includes tracking of total CO2 flow and base volume dispensed. Can send email alerts '
+               'if pH goes outside danger range.',
+
+    'options_enabled': [
+        'custom_options',
+        'function_status'
+    ],
+    'options_disabled': [
+        'measurements_select',
+        'measurements_configure'
+    ],
+
+    'custom_commands': [
+        {
+            'type': 'message',
+            'default_value': 'Reset tracking totals for CO2 flow and base volume dispensed.'
+        },
+        {
+            'id': 'reset_all_totals',
+            'type': 'button',
+            'wait_for_return': True,
+            'name': 'Reset All Totals'
+        },
+        {
+            'id': 'reset_co2_total',
+            'type': 'button',
+            'wait_for_return': True,
+            'name': 'Reset CO2 Flow Total'
+        },
+        {
+            'id': 'reset_base_total',
+            'type': 'button',
+            'wait_for_return': True,
+            'name': 'Reset Base Volume Total'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': 'Reset email notification timer.'
+        },
+        {
+            'id': 'reset_email_timer',
+            'type': 'button',
+            'wait_for_return': True,
+            'name': 'Reset Email Timer'
+        }
+    ],
+
+    'custom_options': [
+        {
+            'type': 'message',
+            'default_value': '<strong>Timing Settings</strong>'
+        },
+        {
+            'id': 'period',
+            'type': 'float',
+            'default_value': 60,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('Period (seconds)'),
+            'phrase': 'How often to check pH and adjust outputs'
+        },
+        {
+            'id': 'start_offset',
+            'type': 'integer',
+            'default_value': 10,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('Start Offset (seconds)'),
+            'phrase': 'Wait time before starting control loop'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>pH Measurement</strong>'
+        },
+        {
+            'id': 'select_measurement_ph',
+            'type': 'select_measurement',
+            'default_value': '',
+            'required': True,
+            'options_select': [
+                'Input',
+                'Function'
+            ],
+            'name': 'pH Measurement',
+            'phrase': 'Select the pH sensor input'
+        },
+        {
+            'id': 'measurement_max_age_ph',
+            'type': 'integer',
+            'default_value': 120,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': lazy_gettext('Max Age (seconds)'),
+            'phrase': 'Maximum age of pH measurement before stopping'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>Output: CO2 for Lowering pH</strong>'
+        },
+        {
+            'id': 'output_co2_lower',
+            'type': 'select_measurement_channel',
+            'default_value': '',
+            'required': True,
+            'options_select': [
+                'Output_Channels_Measurements',
+            ],
+            'name': 'CO2 Mass Flow Controller',
+            'phrase': 'Select the Alicat MFC output for CO2 (lowers pH)'
+        },
+        {
+            'id': 'co2_flow_high',
+            'type': 'float',
+            'default_value': 50.0,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': 'CO2 High Flow Rate (mL/min)',
+            'phrase': 'CO2 flow when actively lowering pH'
+        },
+        {
+            'id': 'co2_flow_maintain',
+            'type': 'float',
+            'default_value': 10.0,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': 'CO2 Maintain Flow Rate (mL/min)',
+            'phrase': 'CO2 flow when maintaining pH (can be 0)'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>Output: Base for Raising pH</strong>'
+        },
+        {
+            'id': 'output_base_raise',
+            'type': 'select_channel',
+            'default_value': '',
+            'required': True,
+            'options_select': [
+                'Output_Channels'
+            ],
+            'name': 'Base Pump Output',
+            'phrase': 'Select pump output for base solution (raises pH)'
+        },
+        {
+            'id': 'output_base_type',
+            'type': 'select',
+            'default_value': 'volume_ml',
+            'required': True,
+            'options_select': [
+                ('duration_sec', 'Duration (seconds)'),
+                ('volume_ml', 'Volume (ml)')
+            ],
+            'name': 'Base Output Type',
+            'phrase': 'Duration or volume for base pump'
+        },
+        {
+            'id': 'base_dose_amount',
+            'type': 'float',
+            'default_value': 1.0,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': 'Base Dose Amount',
+            'phrase': 'Amount to dose when raising pH (seconds or ml)'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>pH Control Range</strong>'
+        },
+        {
+            'id': 'setpoint_ph',
+            'type': 'float',
+            'default_value': 7.0,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': 'pH Setpoint',
+            'phrase': 'Target pH value'
+        },
+        {
+            'id': 'hysteresis_ph',
+            'type': 'float',
+            'default_value': 0.2,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': 'pH Hysteresis',
+            'phrase': 'Control band (+/-) around setpoint'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>pH Danger Range (for email alerts)</strong>'
+        },
+        {
+            'id': 'danger_range_ph_high',
+            'type': 'float',
+            'default_value': 8.5,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': 'pH Danger High',
+            'phrase': 'Critical high pH value for alerts'
+        },
+        {
+            'id': 'danger_range_ph_low',
+            'type': 'float',
+            'default_value': 5.5,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': 'pH Danger Low',
+            'phrase': 'Critical low pH value for alerts'
+        },
+        {
+            'type': 'new_line'
+        },
+        {
+            'type': 'message',
+            'default_value': '<strong>Email Notifications (Optional)</strong>'
+        },
+        {
+            'id': 'email_notification',
+            'type': 'text',
+            'default_value': '',
+            'name': 'Notification Email',
+            'phrase': 'Email address for alerts (blank to disable)'
+        },
+        {
+            'id': 'email_timer_duration_hours',
+            'type': 'float',
+            'default_value': 12.0,
+            'required': True,
+            'constraints_pass': constraints_pass_positive_value,
+            'name': 'Email Timer Duration (Hours)',
+            'phrase': 'Minimum time between notification emails'
+        }
+    ]
+}
+
+
+class CustomModule(AbstractFunction):
+    """
+    pH Control using CO2 MFC and Base Pump
+    """
+    def __init__(self, function, testing=False):
+        super().__init__(function, testing=testing, name=__name__)
+
+        self.control = DaemonControl()
+        self.timer_loop = time.time()
+        
+        # Timing
+        self.period = None
+        self.start_offset = None
+
+        # Measurement
+        self.select_measurement_ph_device_id = None
+        self.select_measurement_ph_measurement_id = None
+        self.measurement_max_age_ph = None
+
+        # Outputs
+        self.output_co2_lower_device_id = None
+        self.output_co2_lower_measurement_id = None
+        self.output_co2_lower_channel_id = None
+        self.output_co2_lower_channel = None
+        self.co2_flow_high = None
+        self.co2_flow_maintain = None
+
+        self.output_base_raise_device_id = None
+        self.output_base_raise_channel_id = None
+        self.output_base_raise_channel = None
+        self.output_base_type = None
+        self.base_dose_amount = None
+
+        # Setpoints
+        self.setpoint_ph = None
+        self.hysteresis_ph = None
+        self.danger_range_ph_high = None
+        self.danger_range_ph_low = None
+        self.range_ph = None
+
+        # Email
+        self.email_notification = None
+        self.email_timer_duration_hours = None
+        self.email_timer = 0
+
+        # Totals tracking
+        self.total_co2_flow_time = None
+        self.total_base_sec = None
+        self.total_base_ml = None
+
+        # Current state
+        self.current_state = None
+
+        # Set custom options
+        custom_function = db_retrieve_table_daemon(
+            CustomController, unique_id=self.unique_id)
+        self.setup_custom_options(
+            FUNCTION_INFORMATION['custom_options'], custom_function)
+
+        if not testing:
+            self.try_initialize()
+
+    def initialize(self):
+        """Initialize the controller"""
+        self.timer_loop = time.time() + self.start_offset
+        
+        # Calculate pH range
+        self.range_ph = (
+            self.setpoint_ph - self.hysteresis_ph,
+            self.setpoint_ph + self.hysteresis_ph
+        )
+
+        # Get output channels
+        self.output_co2_lower_channel = self.get_output_channel_from_channel_id(
+            self.output_co2_lower_channel_id)
+        self.output_base_raise_channel = self.get_output_channel_from_channel_id(
+            self.output_base_raise_channel_id)
+
+        # Initialize totals if not set
+        if self.get_custom_option("total_co2_flow_time") is None:
+            self.total_co2_flow_time = self.set_custom_option("total_co2_flow_time", 0)
+        else:
+            self.total_co2_flow_time = self.get_custom_option("total_co2_flow_time")
+
+        if self.get_custom_option("total_base_sec") is None:
+            self.total_base_sec = self.set_custom_option("total_base_sec", 0)
+        else:
+            self.total_base_sec = self.get_custom_option("total_base_sec")
+
+        if self.get_custom_option("total_base_ml") is None:
+            self.total_base_ml = self.set_custom_option("total_base_ml", 0)
+        else:
+            self.total_base_ml = self.get_custom_option("total_base_ml")
+
+        # Handle multiple email addresses
+        if self.email_notification and "," in self.email_notification:
+            self.email_notification = self.email_notification.split(",")
+
+        self.logger.info(
+            f"pH Dual Control started: Setpoint={self.setpoint_ph:.2f}, "
+            f"Range={self.range_ph[0]:.2f}-{self.range_ph[1]:.2f}, "
+            f"Danger Range={self.danger_range_ph_low:.2f}-{self.danger_range_ph_high:.2f}, "
+            f"CO2 Flow: High={self.co2_flow_high} mL/min, Maintain={self.co2_flow_maintain} mL/min, "
+            f"Base Dose={self.base_dose_amount} {self.output_base_type}")
+
+    def loop(self):
+        """Main control loop"""
+        if self.timer_loop > time.time():
+            return
+
+        while self.timer_loop < time.time():
+            self.timer_loop += self.period
+
+        # Get latest pH measurement
+        last_measurement_ph = self.get_last_measurement(
+            self.select_measurement_ph_device_id,
+            self.select_measurement_ph_measurement_id,
+            max_age=self.measurement_max_age_ph)
+
+        if not last_measurement_ph or last_measurement_ph[1] is None:
+            self.logger.error("No pH measurement available. Stopping CO2 flow for safety.")
+            self.set_co2_flow(0, "SAFETY_STOP")
+            
+            if self.email_notification:
+                if self.email_timer < time.time():
+                    self.email_timer = time.time() + (self.email_timer_duration_hours * 60 * 60)
+                    self.send_email("Warning: No pH measurement available!")
+            return
+
+        current_ph = last_measurement_ph[1]
+
+        # Priority 1: Check if pH is in DANGER range
+        if current_ph < self.danger_range_ph_low:
+            # Dangerously low pH - dose base immediately
+            message = (f"DANGER: pH critically low at {current_ph:.2f} "
+                      f"(should be > {self.danger_range_ph_low:.2f}). "
+                      f"Dosing {self.base_dose_amount} {self.output_base_type} base.")
+            self.logger.warning(message)
+            self.dose_base()
+            
+            if self.email_notification:
+                if self.email_timer < time.time():
+                    self.email_timer = time.time() + (self.email_timer_duration_hours * 60 * 60)
+                    self.send_email(message)
+            return
+
+        elif current_ph > self.danger_range_ph_high:
+            # Dangerously high pH - max CO2 flow immediately
+            message = (f"DANGER: pH critically high at {current_ph:.2f} "
+                      f"(should be < {self.danger_range_ph_high:.2f}). "
+                      f"Setting CO2 to maximum flow {self.co2_flow_high} mL/min.")
+            self.logger.warning(message)
+            self.set_co2_flow(self.co2_flow_high, "DANGER_HIGH")
+            
+            if self.email_notification:
+                if self.email_timer < time.time():
+                    self.email_timer = time.time() + (self.email_timer_duration_hours * 60 * 60)
+                    self.send_email(message)
+            return
+
+        # Priority 2: Normal regulation within hysteresis range
+        if current_ph < self.range_ph[0]:
+            # pH too low - dose base to raise it
+            self.logger.info(
+                f"pH {current_ph:.2f} < {self.range_ph[0]:.2f}. "
+                f"Dosing {self.base_dose_amount} {self.output_base_type} base.")
+            self.dose_base()
+            self.set_co2_flow(0, "pH_LOW")  # Stop CO2 while raising pH
+
+        elif current_ph > self.range_ph[1]:
+            # pH too high - increase CO2 flow to lower it
+            self.logger.info(
+                f"pH {current_ph:.2f} > {self.range_ph[1]:.2f}. "
+                f"Setting CO2 to {self.co2_flow_high} mL/min.")
+            self.set_co2_flow(self.co2_flow_high, "pH_HIGH")
+
+        else:
+            # pH in range - maintain with low CO2 flow
+            self.logger.debug(
+                f"pH {current_ph:.2f} in range {self.range_ph[0]:.2f}-{self.range_ph[1]:.2f}. "
+                f"Maintaining with {self.co2_flow_maintain} mL/min CO2.")
+            self.set_co2_flow(self.co2_flow_maintain, "pH_OK")
+
+    def set_co2_flow(self, flow_rate, state):
+        """Set CO2 MFC flow rate"""
+        self.control.output_on(
+            self.output_co2_lower_device_id,
+            output_type='value',
+            amount=flow_rate,
+            output_channel=self.output_co2_lower_channel)
+        
+        # Track total CO2 flow time
+        self.total_co2_flow_time = self.set_custom_option(
+            "total_co2_flow_time",
+            self.get_custom_option("total_co2_flow_time") + self.period)
+        
+        if state != self.current_state:
+            self.current_state = state
+
+    def dose_base(self):
+        """Dose base solution to raise pH"""
+        base_type = 'vol' if self.output_base_type == 'volume_ml' else 'sec'
+        
+        output_on_off = threading.Thread(
+            target=self.control.output_on_off,
+            args=(self.output_base_raise_device_id, "on",),
+            kwargs={'output_type': base_type,
+                    'amount': self.base_dose_amount,
+                    'output_channel': self.output_base_raise_channel})
+        output_on_off.start()
+
+        # Track totals
+        if base_type == 'sec':
+            self.total_base_sec = self.set_custom_option(
+                "total_base_sec",
+                self.get_custom_option("total_base_sec") + self.base_dose_amount)
+        else:
+            self.total_base_ml = self.set_custom_option(
+                "total_base_ml",
+                self.get_custom_option("total_base_ml") + self.base_dose_amount)
+
+    def send_email(self, message):
+        """Send email notification"""
+        try:
+            smtp = db_retrieve_table_daemon(SMTP, entry='first')
+            send_email(smtp.host, smtp.protocol, smtp.port,
+                      smtp.user, smtp.passw, smtp.email_from,
+                      self.email_notification, message)
+        except Exception as e:
+            self.logger.error(f"Failed to send email: {e}")
+
+    def stop_function(self):
+        """Called when function is deactivated"""
+        self.logger.info("pH Dual Control stopping - setting CO2 flow to 0")
+        if self.output_co2_lower_channel is not None:
+            self.set_co2_flow(0, "STOPPED")
+
+    # Custom command functions
+    def reset_all_totals(self, args_dict):
+        """Reset all tracking totals"""
+        self.total_co2_flow_time = self.set_custom_option("total_co2_flow_time", 0)
+        self.total_base_sec = self.set_custom_option("total_base_sec", 0)
+        self.total_base_ml = self.set_custom_option("total_base_ml", 0)
+        return "All totals reset successfully"
+
+    def reset_co2_total(self, args_dict):
+        """Reset CO2 flow time total"""
+        self.total_co2_flow_time = self.set_custom_option("total_co2_flow_time", 0)
+        return "CO2 flow total reset successfully"
+
+    def reset_base_total(self, args_dict):
+        """Reset base dose totals"""
+        self.total_base_sec = self.set_custom_option("total_base_sec", 0)
+        self.total_base_ml = self.set_custom_option("total_base_ml", 0)
+        return "Base dose totals reset successfully"
+
+    def reset_email_timer(self, args_dict):
+        """Reset email notification timer"""
+        self.email_timer = 0
+        return "Email timer reset successfully"
+
+    def function_status(self):
+        """Return status information for UI"""
+        return_str = {
+            'string_status': 
+                f"<strong>pH Regulation</strong>"
+                f"<br>Target: {self.setpoint_ph:.2f} ± {self.hysteresis_ph:.2f} "
+                f"(Range: {self.range_ph[0]:.2f} - {self.range_ph[1]:.2f})"
+                f"<br>Danger Range: {self.danger_range_ph_low:.2f} - {self.danger_range_ph_high:.2f}"
+                f"<br>"
+                f"<br><strong>CO2 MFC (Lower pH)</strong>"
+                f"<br>High Flow: {self.co2_flow_high} mL/min"
+                f"<br>Maintain Flow: {self.co2_flow_maintain} mL/min"
+                f"<br>Total Flow Time: {self.total_co2_flow_time:.1f} seconds"
+                f"<br>"
+                f"<br><strong>Base Pump (Raise pH)</strong>"
+                f"<br>Dose Amount: {self.base_dose_amount} {self.output_base_type}"
+                f"<br>Total Dispensed: {self.total_base_sec:.2f} sec, {self.total_base_ml:.2f} ml"
+                f"<br>"
+                f"<br>State: {self.current_state if self.current_state else 'Initializing'}",
+            'error': []
+        }
+        return return_str

--- a/custom_inputs/alicat mfc/CHANGELOG.md
+++ b/custom_inputs/alicat mfc/CHANGELOG.md
@@ -1,0 +1,35 @@
+## Changelog - Alicat Mass Flow Controller Input
+
+### Version 1.0 (2025-01-14)
+
+**Initial Release**
+
+**Features:**
+- Read volumetric flow rate from Alicat MFC via Modbus RTU
+- Read mass flow rate in standard conditions
+- Monitor absolute pressure
+- Monitor gas temperature
+- Read current active setpoint
+- Configurable serial port and slave ID
+- Automatic byte-order handling for IEEE 754 floats
+- 8 float values from registers 1349-1364
+
+**Technical Details:**
+- Serial configuration: 19200 baud, 8N2
+- Modbus function code 3 (Read Holding Registers)
+- Swapped register order conversion for float values
+- 1-second timeout with automatic buffer clearing
+
+**Dependencies:**
+- minimalmodbus (Modbus RTU communication)
+- pyserial (serial port handling)
+
+**Compatibility:**
+- Tested with Alicat MC-Series and MQ-Series controllers
+- Compatible with any Alicat device supporting Modbus RTU
+- Mycodo >= 8.0.0
+
+**Notes:**
+- Units configured for mL/min (milliliters per minute)
+- Registers read provide real-time process values
+- Lock file used to prevent concurrent serial access

--- a/custom_inputs/alicat mfc/README.md
+++ b/custom_inputs/alicat mfc/README.md
@@ -1,0 +1,159 @@
+#### Custom Input: Alicat Mass Flow Controller (Modbus RTU)
+
+Version 1.0
+
+#### About
+
+This Input module reads telemetry data from Alicat Mass Flow Controllers via Modbus RTU serial communication. It provides real-time monitoring of volumetric flow, mass flow, pressure, temperature, and current setpoint values.
+
+The module uses the Modbus RTU protocol over RS-485 serial connection to communicate with Alicat devices. All measurements are read from the controller's primary data registers (1349-1364) which provide the most up-to-date process values.
+
+#### Measurements
+
+- **Volumetric Flow Rate** - Standard flow rate in mL/min
+- **Mass Flow Rate** - Mass flow in standard mL/min (SCCM)
+- **Pressure** - Absolute pressure in PSI
+- **Temperature** - Gas temperature in °C
+- **Setpoint** - Current active setpoint in standard mL/min
+
+#### Requirements
+
+- Mycodo >= 8.0.0
+- Alicat Mass Flow Controller with Modbus RTU capability
+- USB-RS485 adapter (e.g., FTDI-based)
+- Python packages (pre-installed in Mycodo):
+  - `minimalmodbus` - Modbus RTU communication
+  - `pyserial` - Serial port handling
+
+#### Hardware Setup
+
+1. **Connect USB-RS485 Adapter:**
+   - Connect the RS-485 adapter to a Raspberry Pi USB port
+   - Identify the serial device (typically `/dev/ttyUSB0`)
+
+2. **Wire RS-485 Connection:**
+   - Connect adapter A/B terminals to controller's Modbus terminals
+   - Ensure proper polarity (A to A, B to B)
+   - Add 120Ω termination resistor if at end of bus
+
+3. **Configure Controller:**
+   - Set controller to Modbus RTU mode
+   - Configure serial settings: 19200 baud, 8N2
+   - Note the Slave ID (default is 1)
+
+#### Software Setup
+
+1. **Import Module:**
+   - Navigate to `[Gear Icon] → Configure → Custom Inputs`
+   - Click "Import Custom Input"
+   - Upload `alicat_mfc_input.py`
+
+2. **Add Input:**
+   - Go to `Setup → Input`
+   - Select "Mass Flow Controller (Telemetry)"
+   - Configure:
+     - **UART Device**: Serial port path (e.g., `/dev/ttyUSB0`)
+     - **Slave ID**: Modbus address (1-247, typically 1)
+     - **Period**: Measurement interval in seconds (recommended: 5-30s)
+
+3. **Activate:**
+   - Click "Activate" to start reading measurements
+   - View data on Dashboard or Live Measurements page
+
+#### Configuration Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| UART Device | Serial port path for Modbus communication | `/dev/ttyUSB0` |
+| Slave ID | Modbus slave address (1-247) | 1 |
+| Period | Measurement interval in seconds | 5 |
+
+#### Technical Details
+
+**Serial Configuration:**
+- Baud Rate: 19200
+- Data Bits: 8
+- Parity: None
+- Stop Bits: 2
+- Timeout: 1.0 second
+
+**Modbus Register Map:**
+- Base Address: 1349
+- Register Count: 16 (8 float values)
+- Function Code: 3 (Read Holding Registers)
+- Data Format: IEEE 754 32-bit floats with swapped register order
+
+**Register Layout:**
+| Registers | Data | Unit |
+|-----------|------|------|
+| 1349-1350 | Setpoint | Device units |
+| 1351-1352 | Valve Drive | % |
+| 1353-1354 | Pressure | Device units |
+| 1355-1356 | Secondary Pressure | Device units |
+| 1357-1358 | Barometric Pressure | Device units |
+| 1359-1360 | Temperature | °C |
+| 1361-1362 | Volumetric Flow | Device units |
+| 1363-1364 | Mass Flow | Device units |
+
+#### Troubleshooting
+
+**Module Won't Import:**
+- Verify Python syntax: `python3 -m py_compile alicat_mfc_input.py`
+- Check Mycodo logs: `tail -f /var/log/mycodo/mycodo.log`
+
+**Serial Communication Errors:**
+- Verify device exists: `ls -la /dev/ttyUSB*`
+- Check permissions: `sudo usermod -a -G dialout mycodo`
+- Test with standalone script: `python3 /opt/Mycodo/env/bin/python alicat_mfc_controller.py`
+
+**No Measurements Recorded:**
+- Confirm input is activated in Mycodo
+- Check serial connection and wiring
+- Verify Modbus slave ID matches controller
+- Review logs for timeout or checksum errors
+
+**Incorrect Values:**
+- Ensure byte-order swapping is correct for your controller model
+- Verify controller is in Modbus RTU mode (not ASCII)
+- Check serial configuration matches controller settings
+
+#### Integration Examples
+
+**Dashboard Widget:**
+Create a line graph showing flow rate over time:
+1. Go to `Setup → Dashboard`
+2. Add "Graph (Synchronous)" widget
+3. Add measurement: "Volumetric Flow Rate"
+4. Set time range (e.g., last 1 hour)
+
+**PID Control:**
+Use flow readings as input to a PID controller:
+1. Go to `Setup → Function`
+2. Add "PID Controller (Basic)"
+3. Set Measurement to "Volumetric Flow Rate"
+4. Configure setpoint and output actions
+
+**Data Export:**
+Export flow data for analysis:
+1. Go to `More → Data Query`
+2. Select "Volumetric Flow Rate" measurement
+3. Set date range
+4. Download CSV
+
+#### Related Modules
+
+- **Alicat MFC Output** - Control setpoint via Modbus
+- **pH Control (CO2 MFC)** - PID controller for pH using CO2 MFC
+- **DO Control (Air MFC)** - PID controller for dissolved oxygen
+
+#### License
+
+GPL v3 (consistent with Mycodo)
+
+#### Support
+
+For issues or questions:
+- Review Mycodo logs: `/var/log/mycodo/mycodo.log`
+- Check serial connection and Modbus configuration
+- Consult Alicat controller manual for register details
+- Post to Mycodo forums or GitHub issues

--- a/custom_inputs/alicat mfc/alicat_mfc_input.py
+++ b/custom_inputs/alicat mfc/alicat_mfc_input.py
@@ -1,0 +1,165 @@
+# coding=utf-8
+"""
+Mycodo custom input module for Alicat Mass Flow Controllers.
+
+Reads volumetric flow, pressure, temperature, and current setpoint so
+the values can be graphed or fed into PID loops.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import struct
+from typing import Dict, Optional
+
+import minimalmodbus
+import serial
+
+from mycodo.inputs.base_input import AbstractInput
+
+
+# ===== Alicat Common Functions =====
+def setup_instrument(port: str, slave_address: int, baudrate: int = 19200, timeout: float = 1.0) -> minimalmodbus.Instrument:
+    """Create and configure a Modbus RTU instrument for the Alicat MFC."""
+    instrument = minimalmodbus.Instrument(port, slaveaddress=slave_address, debug=False)
+    instrument.serial.baudrate = baudrate
+    instrument.serial.bytesize = 8
+    instrument.serial.parity = serial.PARITY_NONE
+    instrument.serial.stopbits = 2
+    instrument.serial.timeout = timeout
+    instrument.mode = minimalmodbus.MODE_RTU
+    instrument.clear_buffers_before_each_transaction = True
+    return instrument
+
+
+def _swapped_registers_to_float(reg_low: int, reg_high: int) -> float:
+    """Convert swapped uint16 registers to IEEE 754 float."""
+    bytes_value = struct.pack('>HH', reg_low, reg_high)
+    return struct.unpack('>f', bytes_value)[0]
+
+
+# Register constants
+DATA_START = 1349
+DATA_COUNT = 16
+
+
+def read_mfc_snapshot(instrument: minimalmodbus.Instrument) -> Dict[str, float]:
+    """Read the primary measurement block from the Alicat controller."""
+    registers = instrument.read_registers(DATA_START, DATA_COUNT, functioncode=3)
+    return {
+        "setpoint": _swapped_registers_to_float(registers[0], registers[1]),
+        "valve_drive": _swapped_registers_to_float(registers[2], registers[3]),
+        "pressure": _swapped_registers_to_float(registers[4], registers[5]),
+        "secondary_pressure": _swapped_registers_to_float(registers[6], registers[7]),
+        "barometric_pressure": _swapped_registers_to_float(registers[8], registers[9]),
+        "temperature": _swapped_registers_to_float(registers[10], registers[11]),
+        "volumetric_flow": _swapped_registers_to_float(registers[12], registers[13]),
+        "mass_flow": _swapped_registers_to_float(registers[14], registers[15]),
+    }
+
+
+# ===== End Alicat Common Functions =====
+
+
+LOCK_NAME = "/var/lock/alicat_mfc"
+
+measurements_dict = {
+    0: {"measurement": "volume_flow_rate", "unit": "ml_min"},
+    1: {"measurement": "mass_flow_rate", "unit": "sml_min"},
+    2: {"measurement": "pressure", "unit": "psi"},
+    3: {"measurement": "temperature", "unit": "C"},
+    4: {"measurement": "setpoint", "unit": "sml_min"},
+}
+
+INPUT_INFORMATION = {
+    "input_name_unique": "alicat_mfc_input",
+    "input_manufacturer": "Alicat",
+    "input_name": "Mass Flow Controller (Telemetry)",
+    "measurements_name": "Flow/Pressure/Temperature",
+    "measurements_dict": measurements_dict,
+    "options_enabled": [
+        "uart_location",
+        "uart_baud_rate",
+        "period",
+        "measurements_select",
+    ],
+    "interfaces": ["UART"],
+    "uart_location": "/dev/ttyUSB0",
+    "uart_baud_rate": 19200,
+    # Dependencies are already installed in the Mycodo environment
+    # Uncomment below if Mycodo's dependency checker is needed
+    # "dependencies_module": [
+    #     ("pip-pypi", "minimalmodbus", "minimalmodbus"),
+    #     ("pip-pypi", "pyserial", "serial"),
+    # ],
+    "custom_options": [
+        {
+            "id": "modbus_address",
+            "type": "integer",
+            "default_value": 1,
+            "required": True,
+            "name": "Modbus Address",
+            "phrase": "RTU slave ID configured on the Alicat.",
+        }
+    ],
+}
+
+
+class InputModule(AbstractInput):
+    """Expose Alicat telemetry as a Mycodo input."""
+
+    def __init__(self, input_dev, testing: bool = False):
+        super().__init__(input_dev, testing=testing, name=__name__)
+        self.instrument = None
+        self.logger = logging.getLogger(__name__)
+        self.modbus_address = 1
+
+        if not testing:
+            self.setup_custom_options(INPUT_INFORMATION["custom_options"], input_dev)
+            self.initialize_input()
+
+    def initialize_input(self):
+        """Establish the Modbus connection."""
+        address = self._get_option_value("modbus_address", default=self.modbus_address)
+        if address is not None:
+            self.modbus_address = int(address)
+
+        port = getattr(self.input_dev, "uart_location", "/dev/ttyUSB0")
+        baudrate = getattr(self.input_dev, "baud_rate", 19200)
+        timeout = getattr(self.input_dev, "uart_timeout", 1.0)
+
+        self.instrument = setup_instrument(port, self.modbus_address, baudrate, timeout)
+
+    def _get_option_value(self, option_id: str, default: Optional[int] = None):
+        """Utility to fetch a custom option value if it exists."""
+        option = getattr(self, "options_custom", {}).get(option_id)
+        if option is None:
+            return default
+        return option.get("value", default)
+
+    def get_measurement(self):
+        """Poll the Alicat and populate measurement channels."""
+        if self.instrument is None:
+            self.initialize_input()
+
+        self.return_dict = copy.deepcopy(measurements_dict)
+
+        try:
+            snapshot = read_mfc_snapshot(self.instrument)
+        except Exception as exc:  # pragma: no cover - requires hardware
+            self.logger.exception("Failed to read Alicat registers: %s", exc)
+            return self.return_dict
+
+        if self.is_enabled(0):
+            self.value_set(0, snapshot["volumetric_flow"])
+        if self.is_enabled(1):
+            self.value_set(1, snapshot["mass_flow"])
+        if self.is_enabled(2):
+            self.value_set(2, snapshot["pressure"])
+        if self.is_enabled(3):
+            self.value_set(3, snapshot["temperature"])
+        if self.is_enabled(4):
+            self.value_set(4, snapshot["setpoint"])
+
+        return self.return_dict

--- a/custom_inputs/hamilton arc do probe/CHANGELOG.md
+++ b/custom_inputs/hamilton arc do probe/CHANGELOG.md
@@ -1,0 +1,46 @@
+## Changelog - Hamilton DO Probe Input
+
+### Version 1.0 (2025-01-14)
+
+**Initial Release**
+
+**Features:**
+- Read dissolved oxygen (DO) value from Hamilton ARC DO probe via Modbus RTU
+- Read integrated temperature sensor value
+- Hamilton-specific byte-order conversion for float values
+- Configurable serial port and baud rate
+- 10-register read pattern for robust data retrieval
+
+**Technical Details:**
+- Serial configuration: 19200 baud, 8N2
+- Modbus function code 3 (Read Holding Registers)
+- DO register: 2089
+- Temperature register: 2409
+- Custom byte-order: combines registers[3] and registers[2] as little-endian float
+- 1-second timeout with automatic buffer clearing
+
+**Byte Order Logic:**
+```python
+# Read 10 registers starting at base
+registers = read_registers(start, 10)
+# Extract 32-bit value from registers 2 and 3
+int_value = (registers[3] << 16) | registers[2]
+# Convert to little-endian float
+float_value = struct.unpack('f', int_value.to_bytes(4, 'little'))[0]
+```
+
+**Dependencies:**
+- minimalmodbus (Modbus RTU communication)
+- pyserial (serial port handling)
+
+**Compatibility:**
+- Tested with Hamilton ARC DO sensors
+- Compatible with Hamilton probes supporting Modbus RTU
+- Mycodo >= 8.0.0
+
+**Notes:**
+- Units: mg/L (dissolved oxygen), °C (Celsius)
+- Calibration must be performed on the probe itself
+- Module reads calibrated values from probe
+- Slave ID typically 1 (configurable per probe)
+- Temperature compensation should be configured on probe

--- a/custom_inputs/hamilton arc do probe/README.md
+++ b/custom_inputs/hamilton arc do probe/README.md
@@ -1,0 +1,198 @@
+#### Custom Input: Hamilton DO Probe (Modbus RTU)
+
+Version 1.0
+
+#### About
+
+This Input module reads dissolved oxygen (DO) and temperature measurements from Hamilton ARC DO probes via Modbus RTU serial communication. Hamilton ARC (Adaptive Real-time Control) sensors provide high-accuracy measurements with digital Modbus RTU communication for industrial and laboratory applications.
+
+The module uses a specialized byte-order conversion for Hamilton's Modbus implementation, reading from registers 2089 (DO) and 2409 (temperature).
+
+#### Measurements
+
+- **Dissolved Oxygen** - DO concentration in mg/L
+- **Temperature** - Probe temperature in °C
+
+#### Requirements
+
+- Mycodo >= 8.0.0
+- Hamilton DO probe with Modbus RTU capability (ARC series)
+- USB-RS485 adapter (e.g., FTDI-based)
+- Python packages (pre-installed in Mycodo):
+  - `minimalmodbus` - Modbus RTU communication
+  - `pyserial` - Serial port handling
+
+#### Hardware Setup
+
+1. **Connect USB-RS485 Adapter:**
+   - Connect the RS-485 adapter to a Raspberry Pi USB port
+   - Identify the serial device (typically `/dev/ttyUSB0`)
+
+2. **Wire RS-485 Connection:**
+   - Connect adapter A/B terminals to probe's Modbus terminals
+   - Ensure proper polarity (A to A, B to B)
+   - Add 120Ω termination resistor if at end of bus
+
+3. **Configure Probe:**
+   - Set probe to Modbus RTU mode
+   - Configure serial settings: 19200 baud, 8N2
+   - Note the Slave ID (typically 1)
+
+#### Software Setup
+
+1. **Import Module:**
+   - Navigate to `[Gear Icon] → Configure → Custom Inputs`
+   - Click "Import Custom Input"
+   - Upload `hamilton_do_input.py`
+
+2. **Add Input:**
+   - Go to `Setup → Input`
+   - Select "DO Probe (Telemetry)"
+   - Configure:
+     - **UART Device**: Serial port path (e.g., `/dev/ttyUSB0`)
+     - **Baud Rate**: 19200 (default, change if probe configured differently)
+     - **Period**: Measurement interval in seconds (recommended: 5-30s)
+
+3. **Activate:**
+   - Click "Activate" to start reading measurements
+   - View data on Dashboard or Live Measurements page
+
+#### Configuration Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| UART Location | Serial port path for Modbus communication | `/dev/ttyUSB0` |
+| Baud Rate | Modbus communication speed | 19200 |
+| Period | Measurement interval in seconds | 5 |
+
+#### Technical Details
+
+**Serial Configuration:**
+- Baud Rate: 19200 (configurable)
+- Data Bits: 8
+- Parity: None
+- Stop Bits: 2
+- Timeout: 1.0 second
+
+**Modbus Register Map:**
+- **DO Register**: 2089 (10 registers read)
+- **Temperature Register**: 2409 (10 registers read)
+- **Function Code**: 3 (Read Holding Registers)
+- **Data Format**: 32-bit float with Hamilton-specific byte order
+
+**Byte Order Conversion:**
+Hamilton probes use a unique register layout:
+```python
+# Read 10 registers starting at base address
+registers = instrument.read_registers(register_start, 10, functioncode=3)
+
+# Combine registers 2 and 3 to form 32-bit value
+int_value = (registers[3] << 16) | registers[2]
+
+# Convert to little-endian bytes and interpret as float
+bytes_value = int_value.to_bytes(4, 'little')
+float_value = struct.unpack('f', bytes_value)[0]
+```
+
+#### Troubleshooting
+
+**Module Won't Import:**
+- Verify Python syntax: `python3 -m py_compile hamilton_do_input.py`
+- Check Mycodo logs: `tail -f /var/log/mycodo/mycodo.log`
+
+**Serial Communication Errors:**
+- Verify device exists: `ls -la /dev/ttyUSB*`
+- Check permissions: `sudo usermod -a -G dialout mycodo`
+- Test serial connection with minimalmodbus directly
+
+**No Measurements Recorded:**
+- Confirm input is activated in Mycodo
+- Check serial connection and wiring
+- Verify Modbus slave ID (typically 1 for Hamilton probes)
+- Review logs for timeout or checksum errors
+
+**Incorrect DO Values:**
+- Verify probe is calibrated
+- Check barometric pressure compensation settings
+- Ensure byte-order conversion matches your probe model
+- Consult Hamilton documentation for your specific probe
+
+**Temperature Reading Issues:**
+- Ensure probe has integrated temperature sensor
+- Verify register 2409 is supported on your probe model
+- Check probe firmware version
+
+#### Integration Examples
+
+**Dashboard DO Monitoring:**
+Create a gauge showing current DO:
+1. Go to `Setup → Dashboard`
+2. Add "Gauge" widget
+3. Select "Dissolved Oxygen" measurement
+4. Set min/max range (e.g., 0 to 10 mg/L)
+
+**DO Control with Air:**
+Use DO readings to control air/O2 flow:
+1. Go to `Setup → Function`
+2. Add "DO Control (Air MFC)" function
+3. Select this DO probe as measurement input
+4. Configure Air MFC as output
+5. Set desired DO setpoint and PID gains
+
+**DO Alert:**
+Send notification if DO drops too low:
+1. Go to `Setup → Conditional`
+2. Add condition: Dissolved Oxygen < 5.0 mg/L
+3. Add action: Send email notification or activate alarm
+
+**Data Logging:**
+Log DO data for compliance/analysis:
+1. DO data automatically logged to InfluxDB
+2. Export via `More → Data Query`
+3. Or integrate with external systems via REST API
+
+**Bioreactor Control:**
+Combine with other sensors for full bioreactor control:
+- DO probe → Air MFC control
+- pH probe → CO2/base MFC control
+- Temperature sensor → Heater/chiller control
+
+#### Calibration
+
+**Note:** This module reads values from the probe but does not perform calibration. Calibrate the probe using:
+- Hamilton's proprietary software
+- Probe's built-in calibration interface
+- Third-party Modbus configuration tools
+
+Typical calibration procedure:
+1. Zero calibration (nitrogen or zero-oxygen solution)
+2. Span calibration (air-saturated water at known temperature)
+3. Verify readings in Mycodo match expected values
+
+#### Specifications
+
+**Typical Hamilton ARC DO Probe Specs:**
+- DO Range: 0-20 mg/L (0-200% saturation)
+- Accuracy: ±0.1 mg/L
+- Temperature Range: 0-50°C
+- Response Time: < 60 seconds (90% in water)
+- Communication: Modbus RTU over RS-485
+
+#### Related Modules
+
+- **Hamilton pH Probe Input** - pH monitoring
+- **DO Control (Air MFC)** - Automated DO control using air/O2
+- **Alicat MFC Output** - Control air/O2 flow for DO regulation
+
+#### License
+
+GPL v3 (consistent with Mycodo)
+
+#### Support
+
+For issues or questions:
+- Review Mycodo logs: `/var/log/mycodo/mycodo.log`
+- Check serial connection and Modbus configuration
+- Consult Hamilton probe manual for register details
+- Verify probe firmware supports Modbus RTU
+- Post to Mycodo forums or GitHub issues

--- a/custom_inputs/hamilton arc do probe/hamilton_do_input.py
+++ b/custom_inputs/hamilton arc do probe/hamilton_do_input.py
@@ -1,0 +1,147 @@
+# coding=utf-8
+"""
+Mycodo custom input module for Hamilton DO Probe.
+
+Reads dissolved oxygen and temperature from a Hamilton DO probe via Modbus RTU.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import struct
+from typing import Dict, Optional
+
+import minimalmodbus
+import serial
+
+from mycodo.inputs.base_input import AbstractInput
+
+
+# ===== Hamilton Common Functions =====
+def setup_instrument(port: str, slave_address: int, baudrate: int = 19200, timeout: float = 1.0) -> minimalmodbus.Instrument:
+    """Create and configure a Modbus RTU instrument for Hamilton probes."""
+    instrument = minimalmodbus.Instrument(port, slaveaddress=slave_address, debug=False)
+    instrument.serial.baudrate = baudrate
+    instrument.serial.bytesize = 8
+    instrument.serial.parity = serial.PARITY_NONE
+    instrument.serial.stopbits = 2
+    instrument.serial.timeout = timeout
+    instrument.mode = minimalmodbus.MODE_RTU
+    instrument.clear_buffers_before_each_transaction = True
+    return instrument
+
+
+def read_float_value(instrument: minimalmodbus.Instrument, register_start: int) -> float:
+    """Read a floating point value from registers using Hamilton's byte order."""
+    values = instrument.read_registers(register_start, 10, functioncode=3)
+    
+    # Combine the register values to form 32-bit integer (Hamilton format)
+    int_value = (values[3] << 16) | values[2]
+    
+    # Convert the 32-bit integer to bytes (little-endian)
+    bytes_value = int_value.to_bytes(4, 'little')
+    
+    # Interpret the bytes as 32-bit float
+    float_value = struct.unpack('f', bytes_value)[0]
+    
+    return float_value
+
+
+# Register constants for Hamilton probes
+DO_REGISTER = 2089
+TEMP_REGISTER = 2409
+
+# ===== End Hamilton Common Functions =====
+
+
+measurements_dict = {
+    0: {"measurement": "dissolved_oxygen", "unit": "mg_L"},
+    1: {"measurement": "temperature", "unit": "C"},
+}
+
+INPUT_INFORMATION = {
+    "input_name_unique": "hamilton_do_input",
+    "input_manufacturer": "Hamilton",
+    "input_name": "DO Probe (Telemetry)",
+    "measurements_name": "Dissolved Oxygen/Temperature",
+    "measurements_dict": measurements_dict,
+    "options_enabled": [
+        "uart_location",
+        "uart_baud_rate",
+        "period",
+        "measurements_select",
+    ],
+    "interfaces": ["UART"],
+    "uart_location": "/dev/ttyUSB0",
+    "uart_baud_rate": 19200,
+    # Dependencies are already installed in the Mycodo environment
+    # Uncomment below if Mycodo's dependency checker is needed
+    # "dependencies_module": [
+    #     ("pip-pypi", "minimalmodbus", "minimalmodbus"),
+    #     ("pip-pypi", "pyserial", "serial"),
+    # ],
+    "custom_options": [
+        {
+            "id": "modbus_address",
+            "type": "integer",
+            "default_value": 5,
+            "required": True,
+            "name": "Modbus Address",
+            "phrase": "RTU slave ID configured on the Hamilton DO probe.",
+        }
+    ],
+}
+
+
+class InputModule(AbstractInput):
+    """Expose Hamilton DO probe telemetry as a Mycodo input."""
+
+    def __init__(self, input_dev, testing: bool = False):
+        super().__init__(input_dev, testing=testing, name=__name__)
+        self.instrument = None
+        self.logger = logging.getLogger(__name__)
+        self.modbus_address = 5
+
+        if not testing:
+            self.setup_custom_options(INPUT_INFORMATION["custom_options"], input_dev)
+            self.initialize_input()
+
+    def initialize_input(self):
+        """Establish the Modbus connection."""
+        address = self._get_option_value("modbus_address", default=self.modbus_address)
+        if address is not None:
+            self.modbus_address = int(address)
+
+        port = getattr(self.input_dev, "uart_location", "/dev/ttyUSB0")
+        baudrate = getattr(self.input_dev, "baud_rate", 19200)
+        timeout = getattr(self.input_dev, "uart_timeout", 1.0)
+
+        self.instrument = setup_instrument(port, self.modbus_address, baudrate, timeout)
+
+    def _get_option_value(self, option_id: str, default: Optional[int] = None):
+        """Utility to fetch a custom option value if it exists."""
+        option = getattr(self, "options_custom", {}).get(option_id)
+        if option is None:
+            return default
+        return option.get("value", default)
+
+    def get_measurement(self):
+        """Poll the Hamilton DO probe and populate measurement channels."""
+        if self.instrument is None:
+            self.initialize_input()
+
+        self.return_dict = copy.deepcopy(measurements_dict)
+
+        try:
+            if self.is_enabled(0):
+                do_value = read_float_value(self.instrument, DO_REGISTER)
+                self.value_set(0, do_value)
+            
+            if self.is_enabled(1):
+                temp_value = read_float_value(self.instrument, TEMP_REGISTER)
+                self.value_set(1, temp_value)
+        except Exception as exc:
+            self.logger.exception("Failed to read Hamilton DO probe: %s", exc)
+
+        return self.return_dict

--- a/custom_inputs/hamilton arc ph probe/CHANGELOG.md
+++ b/custom_inputs/hamilton arc ph probe/CHANGELOG.md
@@ -1,0 +1,45 @@
+## Changelog - Hamilton pH Probe Input
+
+### Version 1.0 (2025-01-14)
+
+**Initial Release**
+
+**Features:**
+- Read pH value from Hamilton ARC pH probe via Modbus RTU
+- Read integrated temperature sensor value
+- Hamilton-specific byte-order conversion for float values
+- Configurable serial port and baud rate
+- 10-register read pattern for robust data retrieval
+
+**Technical Details:**
+- Serial configuration: 19200 baud, 8N2
+- Modbus function code 3 (Read Holding Registers)
+- pH register: 2089
+- Temperature register: 2409
+- Custom byte-order: combines registers[3] and registers[2] as little-endian float
+- 1-second timeout with automatic buffer clearing
+
+**Byte Order Logic:**
+```python
+# Read 10 registers starting at base
+registers = read_registers(start, 10)
+# Extract 32-bit value from registers 2 and 3
+int_value = (registers[3] << 16) | registers[2]
+# Convert to little-endian float
+float_value = struct.unpack('f', int_value.to_bytes(4, 'little'))[0]
+```
+
+**Dependencies:**
+- minimalmodbus (Modbus RTU communication)
+- pyserial (serial port handling)
+
+**Compatibility:**
+- Tested with Hamilton ARC pH sensors
+- Compatible with Hamilton probes supporting Modbus RTU
+- Mycodo >= 8.0.0
+
+**Notes:**
+- Units: pH (unitless), °C (Celsius)
+- Calibration must be performed on the probe itself
+- Module reads calibrated values from probe
+- Slave ID typically 1 (configurable per probe)

--- a/custom_inputs/hamilton arc ph probe/README.md
+++ b/custom_inputs/hamilton arc ph probe/README.md
@@ -1,0 +1,192 @@
+#### Custom Input: Hamilton pH Probe (Modbus RTU)
+
+Version 1.0
+
+#### About
+
+This Input module reads pH and temperature measurements from Hamilton ARC pH probes via Modbus RTU serial communication. Hamilton ARC (Adaptive Real-time Control) sensors provide high-accuracy measurements with digital Modbus RTU communication for industrial and laboratory applications.
+
+The module uses a specialized byte-order conversion for Hamilton's Modbus implementation, reading from registers 2089 (pH) and 2409 (temperature).
+
+#### Measurements
+
+- **pH** - pH value (0-14 scale)
+- **Temperature** - Probe temperature in °C
+
+#### Requirements
+
+- Mycodo >= 8.0.0
+- Hamilton pH probe with Modbus RTU capability (ARC series)
+- USB-RS485 adapter (e.g., FTDI-based)
+- Python packages (pre-installed in Mycodo):
+  - `minimalmodbus` - Modbus RTU communication
+  - `pyserial` - Serial port handling
+
+#### Hardware Setup
+
+1. **Connect USB-RS485 Adapter:**
+   - Connect the RS-485 adapter to a Raspberry Pi USB port
+   - Identify the serial device (typically `/dev/ttyUSB0`)
+
+2. **Wire RS-485 Connection:**
+   - Connect adapter A/B terminals to probe's Modbus terminals
+   - Ensure proper polarity (A to A, B to B)
+   - Add 120Ω termination resistor if at end of bus
+
+3. **Configure Probe:**
+   - Set probe to Modbus RTU mode
+   - Configure serial settings: 19200 baud, 8N2
+   - Note the Slave ID (typically 1)
+
+#### Software Setup
+
+1. **Import Module:**
+   - Navigate to `[Gear Icon] → Configure → Custom Inputs`
+   - Click "Import Custom Input"
+   - Upload `hamilton_ph_input.py`
+
+2. **Add Input:**
+   - Go to `Setup → Input`
+   - Select "pH Probe (Telemetry)"
+   - Configure:
+     - **UART Device**: Serial port path (e.g., `/dev/ttyUSB0`)
+     - **Baud Rate**: 19200 (default, change if probe configured differently)
+     - **Period**: Measurement interval in seconds (recommended: 5-30s)
+
+3. **Activate:**
+   - Click "Activate" to start reading measurements
+   - View data on Dashboard or Live Measurements page
+
+#### Configuration Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| UART Location | Serial port path for Modbus communication | `/dev/ttyUSB0` |
+| Baud Rate | Modbus communication speed | 19200 |
+| Period | Measurement interval in seconds | 5 |
+
+#### Technical Details
+
+**Serial Configuration:**
+- Baud Rate: 19200 (configurable)
+- Data Bits: 8
+- Parity: None
+- Stop Bits: 2
+- Timeout: 1.0 second
+
+**Modbus Register Map:**
+- **pH Register**: 2089 (10 registers read)
+- **Temperature Register**: 2409 (10 registers read)
+- **Function Code**: 3 (Read Holding Registers)
+- **Data Format**: 32-bit float with Hamilton-specific byte order
+
+**Byte Order Conversion:**
+Hamilton probes use a unique register layout:
+```python
+# Read 10 registers starting at base address
+registers = instrument.read_registers(register_start, 10, functioncode=3)
+
+# Combine registers 2 and 3 to form 32-bit value
+int_value = (registers[3] << 16) | registers[2]
+
+# Convert to little-endian bytes and interpret as float
+bytes_value = int_value.to_bytes(4, 'little')
+float_value = struct.unpack('f', bytes_value)[0]
+```
+
+#### Troubleshooting
+
+**Module Won't Import:**
+- Verify Python syntax: `python3 -m py_compile hamilton_ph_input.py`
+- Check Mycodo logs: `tail -f /var/log/mycodo/mycodo.log`
+
+**Serial Communication Errors:**
+- Verify device exists: `ls -la /dev/ttyUSB*`
+- Check permissions: `sudo usermod -a -G dialout mycodo`
+- Test serial connection with minimalmodbus directly
+
+**No Measurements Recorded:**
+- Confirm input is activated in Mycodo
+- Check serial connection and wiring
+- Verify Modbus slave ID (typically 1 for Hamilton probes)
+- Review logs for timeout or checksum errors
+
+**Incorrect pH Values:**
+- Verify probe is calibrated
+- Check temperature compensation settings on probe
+- Ensure byte-order conversion matches your probe model
+- Consult Hamilton documentation for your specific probe
+
+**Temperature Reading Issues:**
+- Ensure probe has integrated temperature sensor
+- Verify register 2409 is supported on your probe model
+- Check probe firmware version
+
+#### Integration Examples
+
+**Dashboard pH Monitoring:**
+Create a gauge showing current pH:
+1. Go to `Setup → Dashboard`
+2. Add "Gauge" widget
+3. Select "pH" measurement
+4. Set min/max range (e.g., 6.0 to 8.0)
+
+**pH Control with CO2:**
+Use pH readings to control CO2 flow:
+1. Go to `Setup → Function`
+2. Add "pH Control (CO2 MFC)" function
+3. Select this pH probe as measurement input
+4. Configure CO2 MFC as output
+5. Set desired pH setpoint and PID gains
+
+**pH Alert:**
+Send notification if pH goes out of range:
+1. Go to `Setup → Conditional`
+2. Add condition: pH < 6.5 OR pH > 7.5
+3. Add action: Send email notification
+
+**Data Logging:**
+Log pH data for compliance:
+1. pH data automatically logged to InfluxDB
+2. Export via `More → Data Query`
+3. Or integrate with external systems via REST API
+
+#### Calibration
+
+**Note:** This module reads values from the probe but does not perform calibration. Calibrate the probe using:
+- Hamilton's proprietary software
+- Probe's built-in calibration interface
+- Third-party Modbus configuration tools
+
+Typical calibration procedure:
+1. Use standard pH buffers (4.0, 7.0, 10.0)
+2. Follow manufacturer's calibration protocol
+3. Verify readings in Mycodo match buffer values
+
+#### Specifications
+
+**Typical Hamilton ARC pH Probe Specs:**
+- pH Range: 0-14
+- Accuracy: ±0.01 pH
+- Temperature Range: 0-100°C
+- Response Time: < 30 seconds
+- Communication: Modbus RTU over RS-485
+
+#### Related Modules
+
+- **Hamilton DO Probe Input** - Dissolved oxygen monitoring
+- **pH Control (CO2 MFC)** - Automated pH control using CO2
+- **Alicat MFC Output** - Control CO2/acid/base dosing for pH control
+
+#### License
+
+GPL v3 (consistent with Mycodo)
+
+#### Support
+
+For issues or questions:
+- Review Mycodo logs: `/var/log/mycodo/mycodo.log`
+- Check serial connection and Modbus configuration
+- Consult Hamilton probe manual for register details
+- Verify probe firmware supports Modbus RTU
+- Post to Mycodo forums or GitHub issues

--- a/custom_inputs/hamilton arc ph probe/hamilton_ph_input.py
+++ b/custom_inputs/hamilton arc ph probe/hamilton_ph_input.py
@@ -1,0 +1,147 @@
+# coding=utf-8
+"""
+Mycodo custom input module for Hamilton pH Probe.
+
+Reads pH and temperature from a Hamilton pH probe via Modbus RTU.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import struct
+from typing import Dict, Optional
+
+import minimalmodbus
+import serial
+
+from mycodo.inputs.base_input import AbstractInput
+
+
+# ===== Hamilton Common Functions =====
+def setup_instrument(port: str, slave_address: int, baudrate: int = 19200, timeout: float = 1.0) -> minimalmodbus.Instrument:
+    """Create and configure a Modbus RTU instrument for Hamilton probes."""
+    instrument = minimalmodbus.Instrument(port, slaveaddress=slave_address, debug=False)
+    instrument.serial.baudrate = baudrate
+    instrument.serial.bytesize = 8
+    instrument.serial.parity = serial.PARITY_NONE
+    instrument.serial.stopbits = 2
+    instrument.serial.timeout = timeout
+    instrument.mode = minimalmodbus.MODE_RTU
+    instrument.clear_buffers_before_each_transaction = True
+    return instrument
+
+
+def read_float_value(instrument: minimalmodbus.Instrument, register_start: int) -> float:
+    """Read a floating point value from registers using Hamilton's byte order."""
+    values = instrument.read_registers(register_start, 10, functioncode=3)
+    
+    # Combine the register values to form 32-bit integer (Hamilton format)
+    int_value = (values[3] << 16) | values[2]
+    
+    # Convert the 32-bit integer to bytes (little-endian)
+    bytes_value = int_value.to_bytes(4, 'little')
+    
+    # Interpret the bytes as 32-bit float
+    float_value = struct.unpack('f', bytes_value)[0]
+    
+    return float_value
+
+
+# Register constants for Hamilton probes
+PH_REGISTER = 2089
+TEMP_REGISTER = 2409
+
+# ===== End Hamilton Common Functions =====
+
+
+measurements_dict = {
+    0: {"measurement": "ph", "unit": "pH"},
+    1: {"measurement": "temperature", "unit": "C"},
+}
+
+INPUT_INFORMATION = {
+    "input_name_unique": "hamilton_ph_input",
+    "input_manufacturer": "Hamilton",
+    "input_name": "pH Probe (Telemetry)",
+    "measurements_name": "pH/Temperature",
+    "measurements_dict": measurements_dict,
+    "options_enabled": [
+        "uart_location",
+        "uart_baud_rate",
+        "period",
+        "measurements_select",
+    ],
+    "interfaces": ["UART"],
+    "uart_location": "/dev/ttyUSB0",
+    "uart_baud_rate": 19200,
+    # Dependencies are already installed in the Mycodo environment
+    # Uncomment below if Mycodo's dependency checker is needed
+    # "dependencies_module": [
+    #     ("pip-pypi", "minimalmodbus", "minimalmodbus"),
+    #     ("pip-pypi", "pyserial", "serial"),
+    # ],
+    "custom_options": [
+        {
+            "id": "modbus_address",
+            "type": "integer",
+            "default_value": 4,
+            "required": True,
+            "name": "Modbus Address",
+            "phrase": "RTU slave ID configured on the Hamilton pH probe.",
+        }
+    ],
+}
+
+
+class InputModule(AbstractInput):
+    """Expose Hamilton pH probe telemetry as a Mycodo input."""
+
+    def __init__(self, input_dev, testing: bool = False):
+        super().__init__(input_dev, testing=testing, name=__name__)
+        self.instrument = None
+        self.logger = logging.getLogger(__name__)
+        self.modbus_address = 4
+
+        if not testing:
+            self.setup_custom_options(INPUT_INFORMATION["custom_options"], input_dev)
+            self.initialize_input()
+
+    def initialize_input(self):
+        """Establish the Modbus connection."""
+        address = self._get_option_value("modbus_address", default=self.modbus_address)
+        if address is not None:
+            self.modbus_address = int(address)
+
+        port = getattr(self.input_dev, "uart_location", "/dev/ttyUSB0")
+        baudrate = getattr(self.input_dev, "baud_rate", 19200)
+        timeout = getattr(self.input_dev, "uart_timeout", 1.0)
+
+        self.instrument = setup_instrument(port, self.modbus_address, baudrate, timeout)
+
+    def _get_option_value(self, option_id: str, default: Optional[int] = None):
+        """Utility to fetch a custom option value if it exists."""
+        option = getattr(self, "options_custom", {}).get(option_id)
+        if option is None:
+            return default
+        return option.get("value", default)
+
+    def get_measurement(self):
+        """Poll the Hamilton pH probe and populate measurement channels."""
+        if self.instrument is None:
+            self.initialize_input()
+
+        self.return_dict = copy.deepcopy(measurements_dict)
+
+        try:
+            if self.is_enabled(0):
+                ph_value = read_float_value(self.instrument, PH_REGISTER)
+                self.value_set(0, ph_value)
+            
+            if self.is_enabled(1):
+                temp_value = read_float_value(self.instrument, TEMP_REGISTER)
+                self.value_set(1, temp_value)
+        except Exception as exc:
+            self.logger.exception("Failed to read Hamilton pH probe: %s", exc)
+
+        return self.return_dict

--- a/custom_outputs/alicat massflow setpoint/CHANGELOG.md
+++ b/custom_outputs/alicat massflow setpoint/CHANGELOG.md
@@ -1,0 +1,49 @@
+## Changelog - Alicat Mass Flow Controller Output
+
+### Version 1.0 (2025-01-14)
+
+**Initial Release**
+
+**Features:**
+- Write flow setpoint to Alicat MFC via Modbus RTU
+- Value-type output accepting numeric setpoints
+- Automatic verification by reading back setpoint status
+- On/off control (off sets setpoint to 0)
+- Compatible with Mycodo PID controllers
+- Status reporting based on actual setpoint value
+
+**Technical Details:**
+- Serial configuration: 19200 baud, 8N2
+- Write to register 1009 (Register Numbers 1010-1011)
+- Read confirmation from register 1349 (setpoint status)
+- Modbus function codes: 16 (write) and 3 (read)
+- Swapped register order conversion for float values
+- 1-second timeout with automatic buffer clearing
+
+**Control Logic:**
+- `output_switch(state='on', amount=X)` → writes X mL/min
+- `output_switch(state='off')` → writes 0 mL/min
+- `is_on()` → returns True if setpoint > 0.1 mL/min
+- `is_setup()` → returns True if initialized
+
+**Dependencies:**
+- minimalmodbus (Modbus RTU communication)
+- pyserial (serial port handling)
+
+**Compatibility:**
+- Tested with Alicat MC-Series and MQ-Series controllers
+- Compatible with any Alicat device supporting Modbus RTU register 1009
+- Mycodo >= 8.0.0
+
+**Bug Fixes from Development:**
+- Fixed incorrect setpoint register (1349 is read-only, 1009 is write command)
+- Added output_channel parameter to output_switch()
+- Implemented all required abstract methods
+- Added channels_dict definition for value output type
+- Renamed initialize_output() to initialize()
+
+**Notes:**
+- Units configured for mL/min (milliliters per minute)
+- Setpoint writes confirmed by reading back register 1349
+- Lock file used to prevent concurrent serial access
+- Off button functionality sets flow to 0 for safety

--- a/custom_outputs/alicat massflow setpoint/README.md
+++ b/custom_outputs/alicat massflow setpoint/README.md
@@ -1,0 +1,219 @@
+#### Custom Output: Alicat Mass Flow Controller Setpoint Control (Modbus RTU)
+
+Version 1.0
+
+#### About
+
+This Output module controls the setpoint of Alicat Mass Flow Controllers via Modbus RTU serial communication. It provides a value-type output that allows Mycodo automations, PID controllers, or manual commands to dynamically adjust the flow rate.
+
+The module writes setpoint commands to register 1009 (Register Numbers 1010-1011) which is the designated read/write setpoint command register for Alicat controllers. It then reads back the confirmation from register 1349 to verify the setpoint was accepted.
+
+#### Features
+
+- **Dynamic Setpoint Control** - Write flow setpoints in real-time
+- **Value Output Type** - Accepts numeric setpoint values
+- **Verification** - Reads back actual setpoint after writing
+- **On/Off Control** - Off state sets setpoint to 0
+- **PID Integration** - Compatible with Mycodo PID controllers
+- **Status Monitoring** - Reports on/off state based on actual flow setpoint
+
+#### Requirements
+
+- Mycodo >= 8.0.0
+- Alicat Mass Flow Controller with Modbus RTU capability
+- USB-RS485 adapter (e.g., FTDI-based)
+- Python packages (pre-installed in Mycodo):
+  - `minimalmodbus` - Modbus RTU communication
+  - `pyserial` - Serial port handling
+
+#### Hardware Setup
+
+1. **Connect USB-RS485 Adapter:**
+   - Connect the RS-485 adapter to a Raspberry Pi USB port
+   - Identify the serial device (typically `/dev/ttyUSB0`)
+
+2. **Wire RS-485 Connection:**
+   - Connect adapter A/B terminals to controller's Modbus terminals
+   - Ensure proper polarity (A to A, B to B)
+   - Add 120Ω termination resistor if at end of bus
+
+3. **Configure Controller:**
+   - Set controller to Modbus RTU mode
+   - Configure serial settings: 19200 baud, 8N2
+   - Note the Slave ID (default is 1)
+   - Note the maximum flow range for your device
+
+#### Software Setup
+
+1. **Import Module:**
+   - Navigate to `[Gear Icon] → Configure → Custom Outputs`
+   - Click "Import Custom Output"
+   - Upload `alicat_mfc_output.py`
+
+2. **Add Output:**
+   - Go to `Setup → Output`
+   - Select "Mass Flow Controller (Setpoint Control)"
+   - Configure:
+     - **UART Device**: Serial port path (e.g., `/dev/ttyUSB0`)
+     - **Slave ID**: Modbus address (1-247, typically 1)
+     - **Output Name**: Descriptive name (e.g., "CO2 Flow Controller")
+
+3. **Activate:**
+   - Click "Add" to create the output
+   - Output is now ready for manual or automated control
+
+#### Configuration Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| UART Device | Serial port path for Modbus communication | `/dev/ttyUSB0` |
+| Slave ID | Modbus slave address (1-247) | 1 |
+
+#### Using the Output
+
+**Manual Control:**
+1. Go to `Data → Output`
+2. Find your MFC output
+3. Enter setpoint value in mL/min
+4. Click "Turn On" to send the setpoint
+
+**PID Control:**
+1. Go to `Setup → Function`
+2. Add a PID controller
+3. Select your MFC as the "Output"
+4. Configure PID gains and setpoint
+
+**Conditional/Function Control:**
+1. Create a conditional or function
+2. Add action "Execute Output"
+3. Select your MFC and enter desired value
+
+**API Control:**
+```python
+import requests
+
+url = f'https://{pi_ip}/api/outputs/{output_id}'
+headers = {'X-API-KEY': 'your-api-key'}
+data = {'state': True, 'amount': 50.0}  # 50 mL/min
+response = requests.post(url, json=data, headers=headers, verify=False)
+```
+
+#### Technical Details
+
+**Serial Configuration:**
+- Baud Rate: 19200
+- Data Bits: 8
+- Parity: None
+- Stop Bits: 2
+- Timeout: 1.0 second
+
+**Modbus Register Map:**
+- **Write Register**: 1009-1010 (Register Numbers 1010-1011)
+- **Read Register**: 1349-1350 (setpoint status readback)
+- **Function Code**: 16 (Write Multiple Registers) and 3 (Read Holding Registers)
+- **Data Format**: IEEE 754 32-bit floats with swapped register order
+
+**Control Behavior:**
+- `state='on', amount=X` → Sets setpoint to X mL/min
+- `state='off'` → Sets setpoint to 0 mL/min
+- `is_on()` → Returns True if setpoint > 0.1 mL/min
+
+**Register Details:**
+According to Alicat Modbus documentation:
+- Register Numbers 1010-1011 (addresses 1009-1010): Read/Write setpoint command
+- Register Numbers 1350-1351 (addresses 1349-1350): Current setpoint status (read-only)
+
+The module writes the desired setpoint to register 1009, then reads back register 1349 to confirm the controller accepted the command.
+
+#### Troubleshooting
+
+**Module Won't Import:**
+- Verify Python syntax: `python3 -m py_compile alicat_mfc_output.py`
+- Check Mycodo logs: `tail -f /var/log/mycodo/mycodo.log`
+
+**Output Not Responding:**
+- Verify output is added (not just activated)
+- Check serial connection and wiring
+- Verify Modbus slave ID matches controller
+- Test with direct Modbus command
+
+**Setpoint Not Applied:**
+- Ensure controller is not in local control mode
+- Verify register 1009 is writable on your controller model
+- Check for Modbus timeout or checksum errors in logs
+- Confirm value is within controller's rated range (0 to max flow)
+
+**"Unconfigured" Status:**
+- For value outputs, this just means setpoint is 0
+- Use the "On" button with a value to set a non-zero setpoint
+- Or use the "Off" button to explicitly set to 0
+
+#### Integration Examples
+
+**pH Control with CO2:**
+Use the pH Control (CO2 MFC) function:
+1. Go to `Setup → Function`
+2. Add "pH Control (CO2 MFC)"
+3. Select pH sensor as input
+4. Select this MFC output for CO2
+5. Configure PID gains and max flow limit
+
+**DO Control with Air:**
+Use the DO Control (Air MFC) function:
+1. Go to `Setup → Function`
+2. Add "DO Control (Air MFC)"
+3. Select DO sensor as input
+4. Select this MFC output for Air
+5. Configure PID gains and max flow limit
+
+**Flow Ramp Control:**
+Create a custom function to gradually ramp flow:
+```python
+# Gradually increase from 0 to 100 mL/min over 10 minutes
+for i in range(0, 101, 10):
+    self.control.output_on(output_id, amount=i)
+    time.sleep(60)  # Wait 1 minute between steps
+```
+
+**Safety Shutoff:**
+Create a conditional to stop flow if sensor fails:
+1. Go to `Setup → Conditional`
+2. Condition: pH sensor inactive for > 5 minutes
+3. Action: Set MFC output to 0 (off)
+
+#### Safety Considerations
+
+1. **Set Appropriate Limits:**
+   - When using with PID controllers, always set max flow limits
+   - Ensure limits match your process safety requirements
+
+2. **Monitor Sensor Health:**
+   - Use conditionals to stop flow if sensors fail
+   - Set measurement timeout in controller functions
+
+3. **Test Before Deployment:**
+   - Verify setpoint range matches your application
+   - Test emergency stop procedures
+   - Confirm flow measurements match setpoints
+
+4. **Startup/Shutdown Behavior:**
+   - Configure startup state (typically "Off")
+   - Configure shutdown state (typically "Off" for safety)
+
+#### Related Modules
+
+- **Alicat MFC Input** - Monitor flow, pressure, and temperature
+- **pH Control (CO2 MFC)** - Automated pH control using this output
+- **DO Control (Air MFC)** - Automated DO control using this output
+
+#### License
+
+GPL v3 (consistent with Mycodo)
+
+#### Support
+
+For issues or questions:
+- Review Mycodo logs: `/var/log/mycodo/mycodo.log`
+- Check serial connection and Modbus configuration
+- Verify register 1009 is writable (consult Alicat manual)
+- Post to Mycodo forums or GitHub issues

--- a/custom_outputs/alicat massflow setpoint/alicat_mfc_output.py
+++ b/custom_outputs/alicat massflow setpoint/alicat_mfc_output.py
@@ -1,0 +1,238 @@
+# coding=utf-8
+"""
+Mycodo custom output module for driving an Alicat Mass Flow Controller.
+
+Provides a value-type output that writes a new flow setpoint (in the
+units configured on the device) whenever Mycodo automations, PID, or
+manual commands call it.
+"""
+
+from __future__ import annotations
+
+import logging
+import struct
+from typing import Dict, Optional
+
+import minimalmodbus
+import serial
+
+from mycodo.outputs.base_output import AbstractOutput
+
+
+# ===== Alicat Common Functions =====
+def setup_instrument(port: str, slave_address: int, baudrate: int = 19200, timeout: float = 1.0) -> minimalmodbus.Instrument:
+    """Create and configure a Modbus RTU instrument for the Alicat MFC."""
+    instrument = minimalmodbus.Instrument(port, slaveaddress=slave_address, debug=False)
+    instrument.serial.baudrate = baudrate
+    instrument.serial.bytesize = 8
+    instrument.serial.parity = serial.PARITY_NONE
+    instrument.serial.stopbits = 2
+    instrument.serial.timeout = timeout
+    instrument.mode = minimalmodbus.MODE_RTU
+    instrument.clear_buffers_before_each_transaction = True
+    return instrument
+
+
+def _swapped_registers_to_float(reg_low: int, reg_high: int) -> float:
+    """Convert swapped uint16 registers to IEEE 754 float."""
+    bytes_value = struct.pack('>HH', reg_low, reg_high)
+    return struct.unpack('>f', bytes_value)[0]
+
+
+def _float_to_swapped_registers(value: float) -> list[int]:
+    """Convert float to swapped register order required by Alicat."""
+    bytes_value = struct.pack('>f', value)
+    reg_low, reg_high = struct.unpack('>HH', bytes_value)
+    return [reg_low, reg_high]
+
+
+# Register constants
+DATA_START = 1349
+DATA_COUNT = 16
+SETPOINT_REG = 1009  # Write setpoint to register 1009-1010 (Register Numbers 1010-1011)
+
+
+def read_mfc_snapshot(instrument: minimalmodbus.Instrument) -> Dict[str, float]:
+    """Read the primary measurement block from the Alicat controller."""
+    registers = instrument.read_registers(DATA_START, DATA_COUNT, functioncode=3)
+    return {
+        "setpoint": _swapped_registers_to_float(registers[0], registers[1]),
+        "valve_drive": _swapped_registers_to_float(registers[2], registers[3]),
+        "pressure": _swapped_registers_to_float(registers[4], registers[5]),
+        "secondary_pressure": _swapped_registers_to_float(registers[6], registers[7]),
+        "barometric_pressure": _swapped_registers_to_float(registers[8], registers[9]),
+        "temperature": _swapped_registers_to_float(registers[10], registers[11]),
+        "volumetric_flow": _swapped_registers_to_float(registers[12], registers[13]),
+        "mass_flow": _swapped_registers_to_float(registers[14], registers[15]),
+    }
+
+
+def write_setpoint(instrument: minimalmodbus.Instrument, setpoint: float) -> float:
+    """Write a new setpoint (in device units) and return the echoed value."""
+    registers = _float_to_swapped_registers(setpoint)
+    instrument.write_registers(SETPOINT_REG, registers)
+    confirmation = read_mfc_snapshot(instrument)
+    return confirmation["setpoint"]
+
+
+# ===== End Alicat Common Functions =====
+
+
+LOCK_NAME = "/var/lock/alicat_mfc"
+
+measurements_dict = {
+    0: {"measurement": "volume_flow_rate", "unit": "ml_min"},
+}
+
+channels_dict = {
+    0: {
+        'types': ['value'],
+        'measurements': [0]
+    }
+}
+
+OUTPUT_INFORMATION = {
+    "output_name_unique": "alicat_mfc_output",
+    "output_name": "Alicat MFC (Setpoint Control)",
+    "measurements_dict": measurements_dict,
+    "channels_dict": channels_dict,
+    "output_types": ["value"],
+    "interfaces": ["UART"],
+    "options_enabled": [
+        "button_send_value",
+    ],
+    # Dependencies are already installed in the Mycodo environment
+    # Uncomment below if Mycodo's dependency checker is needed
+    # "dependencies_module": [
+    #     ("pip-pypi", "minimalmodbus", "minimalmodbus"),
+    #     ("pip-pypi", "pyserial", "serial"),
+    # ],
+    "custom_options": [
+        {
+            "id": "uart_device",
+            "type": "text",
+            "default_value": "/dev/ttyUSB0",
+            "required": True,
+            "name": "UART Device",
+            "phrase": "Serial device connected to the RS485 adapter.",
+        },
+        {
+            "id": "baud_rate",
+            "type": "integer",
+            "default_value": 19200,
+            "required": True,
+            "name": "Baud Rate",
+        },
+        {
+            "id": "modbus_address",
+            "type": "integer",
+            "default_value": 1,
+            "required": True,
+            "name": "Modbus Address",
+        },
+    ],
+}
+
+
+class OutputModule(AbstractOutput):
+    """Expose Alicat setpoint control as a Mycodo output."""
+
+    def __init__(self, output, testing: bool = False):
+        super().__init__(output, testing=testing, name=__name__)
+        self.instrument = None
+        self.logger = logging.getLogger(__name__)
+        self.uart_device = "/dev/ttyUSB0"
+        self.baud_rate = 19200
+        self.modbus_address = 1
+        self.timeout = 1.0
+
+        if not testing:
+            self.setup_custom_options(OUTPUT_INFORMATION["custom_options"], output)
+
+    def initialize(self):
+        """Open the Modbus serial connection."""
+        self.setup_output_variables(OUTPUT_INFORMATION)
+        
+        self.uart_device = self._get_option_value("uart_device", self.uart_device)
+        baud = self._get_option_value("baud_rate", self.baud_rate)
+        if baud is not None:
+            self.baud_rate = int(baud)
+        address = self._get_option_value("modbus_address", self.modbus_address)
+        if address is not None:
+            self.modbus_address = int(address)
+        timeout = getattr(self.output, "uart_timeout", self.timeout)
+        self.timeout = timeout if timeout else self.timeout
+
+        self.instrument = setup_instrument(
+            self.uart_device, self.modbus_address, self.baud_rate, self.timeout
+        )
+
+    def _get_option_value(self, option_id: str, default: Optional[str] = None):
+        option = getattr(self, "options_custom", {}).get(option_id)
+        if option is None:
+            return default
+        return option.get("value", default)
+
+    def output_switch(self, state, output_type=None, amount=None, output_channel=None):
+        """
+        Handle value writes from Mycodo.
+
+        Args:
+            state: String describing new state ("on"/"off")
+            output_type: Output category (unused)
+            amount: Desired flow setpoint in device units (float)
+            output_channel: Channel number (unused, single channel device)
+        """
+        if self.instrument is None:
+            self.initialize()
+
+        # Handle "off" state by setting setpoint to 0
+        if state == 'off':
+            amount = 0.0
+        
+        if amount is None:
+            self.logger.error("Alicat setpoint write skipped: no amount provided")
+            return False
+
+        try:
+            echoed = write_setpoint(self.instrument, float(amount))
+            self.logger.info(
+                "Set Alicat flow setpoint to %.3f (device echoed %.3f)", amount, echoed
+            )
+            return True
+        except Exception as exc:  # pragma: no cover - requires hardware
+            self.logger.exception("Failed to write Alicat setpoint: %s", exc)
+            return False
+
+    def is_on(self, channel=None):
+        """
+        Required method. Return True if setpoint > 0, False if setpoint is 0.
+        """
+        if self.instrument is None:
+            return False
+        
+        try:
+            snapshot = read_mfc_snapshot(self.instrument)
+            # Consider "on" if setpoint is greater than 0.1 mL/min
+            return snapshot["setpoint"] > 0.1
+        except Exception:
+            return False
+
+    def is_setup(self):
+        """Required method. Return if output is properly initialized."""
+        return self.instrument is not None
+
+    def stop_output(self):
+        """Clean up resources when output is stopped."""
+        self.instrument = None
+
+    def get_current_flow(self) -> Optional[float]:
+        """Optional helper to view latest flow value from the output page."""
+        if self.instrument is None:
+            return None
+
+        try:
+            snapshot = read_mfc_snapshot(self.instrument)
+            return snapshot["volumetric_flow"]
+        except Exception:
+            return None

--- a/sync_custom_and_restart.sh
+++ b/sync_custom_and_restart.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ### CONFIG – adjust if your paths/service name differ
 MYCODO_CUSTOM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MYCODO_ROOT="/var/mycodo-root"
+MYCODO_ROOT="/opt/Mycodo"
 MYCODO_SERVICE="mycodo"
 
 # Source → Destination mappings

--- a/sync_custom_and_restart.sh
+++ b/sync_custom_and_restart.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+### CONFIG – adjust if your paths/service name differ
+MYCODO_CUSTOM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MYCODO_ROOT="/var/mycodo-root"
+MYCODO_SERVICE="mycodo"
+
+# Source → Destination mappings
+declare -A SYNC_DIRS=(
+  ["custom_functions"]="${MYCODO_ROOT}/mycodo/custom_functions"
+  ["custom_inputs"]="${MYCODO_ROOT}/mycodo/custom_inputs"
+  ["custom_outputs"]="${MYCODO_ROOT}/mycodo/custom_outputs"
+)
+
+echo "Using Mycodo-custom root: ${MYCODO_CUSTOM_ROOT}"
+echo "Using Mycodo root:        ${MYCODO_ROOT}"
+echo
+
+# Optional: require root (since we'll restart the service and write into /var)
+if [[ "$EUID" -ne 0 ]]; then
+  echo "Please run as root (e.g. with sudo)." >&2
+  exit 1
+fi
+
+# Ensure destination directories exist
+for SRC in "${!SYNC_DIRS[@]}"; do
+  DEST="${SYNC_DIRS[$SRC]}"
+  if [[ ! -d "$DEST" ]]; then
+    echo "Creating destination directory: $DEST"
+    mkdir -p "$DEST"
+  fi
+done
+
+echo "Syncing custom modules into Mycodo ..."
+
+for SRC in "${!SYNC_DIRS[@]}"; do
+  SRC_PATH="${MYCODO_CUSTOM_ROOT}/${SRC}"
+  DEST_PATH="${SYNC_DIRS[$SRC]}"
+
+  if [[ ! -d "$SRC_PATH" ]]; then
+    echo "Warning: Source directory does not exist, skipping: $SRC_PATH"
+    continue
+  fi
+
+  echo "  -> ${SRC_PATH}  →  ${DEST_PATH}"
+
+  # Only sync new or updated files (based on modification time)
+  # --update: skip files that are newer on the destination
+  # No --delete: keeps existing files in destination
+  rsync -a --update "${SRC_PATH}/" "${DEST_PATH}/"
+done
+
+echo
+echo "Restarting Mycodo service: ${MYCODO_SERVICE}"
+
+# Stop & start or just restart; restart is usually enough
+systemctl restart "${MYCODO_SERVICE}"
+
+echo "Done. Mycodo custom modules synced and service restarted."

--- a/sync_custom_and_restart.sh
+++ b/sync_custom_and_restart.sh
@@ -43,7 +43,16 @@ for SRC in "${!SYNC_DIRS[@]}"; do
     continue
   fi
 
-  echo "  -> ${SRC_PATH}  →  ${DEST_PATH}"
+  echo "  echo "  -> ${SRC_PATH}  →  ${DEST_PATH}"
+
+  # For custom_functions, flatten the structure - copy only .py files from subdirs
+  if [[ "$SRC" == "custom_functions" ]]; then
+    # Copy all .py files recursively, flattening to destination root
+    find "${SRC_PATH}" -name "*.py" -type f ! -name "__*" -exec cp -u {} "${DEST_PATH}/" \;
+  else
+    # For inputs/outputs, sync normally
+    rsync -a --update "${SRC_PATH}/" "${DEST_PATH}/"
+  fi"
 
   # Only sync new or updated files (based on modification time)
   # --update: skip files that are newer on the destination

--- a/sync_custom_and_restart_dryrun.sh
+++ b/sync_custom_and_restart_dryrun.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+### CONFIG – adjust if your paths/service name differ
+MYCODO_CUSTOM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MYCODO_ROOT="/var/mycodo-root"
+MYCODO_SERVICE="mycodo"
+
+# Source → Destination mappings
+declare -A SYNC_DIRS=(
+  ["custom_functions"]="${MYCODO_ROOT}/mycodo/custom_functions"
+  ["custom_inputs"]="${MYCODO_ROOT}/mycodo/custom_inputs"
+  ["custom_outputs"]="${MYCODO_ROOT}/mycodo/custom_outputs"
+)
+
+echo "============================================"
+echo "DRY RUN MODE - No changes will be made"
+echo "============================================"
+echo
+echo "Using Mycodo-custom root: ${MYCODO_CUSTOM_ROOT}"
+echo "Using Mycodo root:        ${MYCODO_ROOT}"
+echo
+
+# Check if running as root
+if [[ "$EUID" -ne 0 ]]; then
+  echo "NOTE: Not running as root. For actual sync, you'll need sudo." >&2
+  echo
+fi
+
+echo "Checking destination directories..."
+for SRC in "${!SYNC_DIRS[@]}"; do
+  DEST="${SYNC_DIRS[$SRC]}"
+  if [[ -d "$DEST" ]]; then
+    echo "  ✓ Destination exists: $DEST"
+  else
+    echo "  ✗ Would create: $DEST"
+  fi
+done
+
+echo
+echo "Files that would be synced:"
+echo
+
+for SRC in "${!SYNC_DIRS[@]}"; do
+  SRC_PATH="${MYCODO_CUSTOM_ROOT}/${SRC}"
+  DEST_PATH="${SYNC_DIRS[$SRC]}"
+
+  if [[ ! -d "$SRC_PATH" ]]; then
+    echo "Warning: Source directory does not exist, would skip: $SRC_PATH"
+    continue
+  fi
+
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "Source: ${SRC_PATH}"
+  echo "Destination: ${DEST_PATH}"
+  echo
+
+  # Use rsync --dry-run to show what would be done
+  # --update: only sync files that are newer in source
+  # No --delete: won't remove any files from destination
+  if [[ -d "$DEST_PATH" ]]; then
+    echo "Files that would be updated or added:"
+    rsync -avin --update "${SRC_PATH}/" "${DEST_PATH}/" || true
+  else
+    echo "All files would be copied (new destination):"
+    rsync -avin --update "${SRC_PATH}/" "${DEST_PATH}/" || true
+  fi
+  echo
+done
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo
+echo "After syncing, would restart service: ${MYCODO_SERVICE}"
+echo "Command: systemctl restart ${MYCODO_SERVICE}"
+echo
+echo "============================================"
+echo "DRY RUN COMPLETE - No changes were made"
+echo "============================================"
+echo
+echo "To perform the actual sync, run:"
+echo "  sudo ./sync_custom_and_restart.sh"

--- a/sync_custom_and_restart_dryrun.sh
+++ b/sync_custom_and_restart_dryrun.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ### CONFIG – adjust if your paths/service name differ
 MYCODO_CUSTOM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MYCODO_ROOT="/var/mycodo-root"
+MYCODO_ROOT="/opt/Mycodo"
 MYCODO_SERVICE="mycodo"
 
 # Source → Destination mappings

--- a/sync_custom_and_restart_dryrun.sh
+++ b/sync_custom_and_restart_dryrun.sh
@@ -55,15 +55,18 @@ for SRC in "${!SYNC_DIRS[@]}"; do
   echo "Destination: ${DEST_PATH}"
   echo
 
-  # Use rsync --dry-run to show what would be done
-  # --update: only sync files that are newer in source
-  # No --delete: won't remove any files from destination
-  if [[ -d "$DEST_PATH" ]]; then
-    echo "Files that would be updated or added:"
-    rsync -avin --update "${SRC_PATH}/" "${DEST_PATH}/" || true
+  if [[ "$SRC" == "custom_functions" ]]; then
+    echo "Files that would be copied (flattened structure):"
+    find "${SRC_PATH}" -name "*.py" -type f ! -name "__*" -exec echo "  {}" \;
   else
-    echo "All files would be copied (new destination):"
-    rsync -avin --update "${SRC_PATH}/" "${DEST_PATH}/" || true
+    # Use rsync --dry-run to show what would be done
+    if [[ -d "$DEST_PATH" ]]; then
+      echo "Files that would be updated or added:"
+      rsync -avin --update "${SRC_PATH}/" "${DEST_PATH}/" || true
+    else
+      echo "All files would be copied (new destination):"
+      rsync -avin --update "${SRC_PATH}/" "${DEST_PATH}/" || true
+    fi
   fi
   echo
 done


### PR DESCRIPTION
This commit adds comprehensive support for Alicat Mass Flow Controllers and Hamilton pH/DO probes via Modbus RTU, enabling automated bioreactor and fermenter control in Mycodo.

New Custom Inputs (3):
- Alicat MFC: Read flow, pressure, temperature telemetry via Modbus RTU
- Hamilton pH Probe: Read pH and temperature via Modbus RTU
- Hamilton DO Probe: Read dissolved oxygen and temperature via Modbus RTU

New Custom Outputs (1):
- Alicat MFC Setpoint Control: Write flow setpoint with verification

New Custom Functions (2 main + 3 variants):
- pH Control (CO2 MFC): PID-based pH control with CO2 dosing
  * PID variant with configurable gains
  * Bang-bang variant for simpler control
  * Dual output variant (CO2 + base pump)
- DO Control (Air MFC): PID-based DO control with air aeration
  * PID variant with configurable gains
  * Bang-bang variant for simpler control

Key Features:
- Complete Modbus RTU implementation (19200 baud, 8N2)
- Correct byte-order handling for Alicat and Hamilton protocols
- PID control with configurable, tunable parameters
- Bang-bang control for applications not requiring precision
- Safety features: flow limits, measurement timeouts, graceful shutdowns
- Comprehensive documentation for each module

Documentation:
- Each module includes detailed README.md with setup, configuration, troubleshooting
- Each module includes CHANGELOG.md with version history
- Main README.rst updated with descriptions of all new modules
- PID tuning guides included for control functions

Testing:
All modules tested and verified on Raspberry Pi 4 with Mycodo 8.15+, Alicat MC/MQ series mass flow controllers, Hamilton ARC series pH/DO probes, and USB-RS485 adapters. Control in a bioreactor system has not been tested, but functions load in mycodo and apply setpoint changes or activate outputs. @kizniche i expect this would be a tricky one for you to verify considering the cost of these sorts of sensors but  I figure id make a pull request anyway as i would love to contribute to this project in some way.

Use Case:
These modules enable complete bioreactor/fermenter control - monitor pH and DO continuously, automatically dose CO2 to maintain pH setpoint, automatically aerate to maintain DO setpoint, with all measurements and control actions logged to InfluxDB.